### PR TITLE
Replace language field on submissions with language id

### DIFF
--- a/src/data-layer/README.md
+++ b/src/data-layer/README.md
@@ -184,7 +184,7 @@ Request Body:
 {
     "user_id": 1,
     "problem_id": 1,
-    "language": "C++",
+    "language_id": 1,
     "source_code": "int main() { return 0 }"
 }
 ```
@@ -197,7 +197,7 @@ Response Body:
     "user_id": 1,
     "problem_id": 1,
     "time_elapsed": 0,
-    "language": "C++",
+    "language_id": 1,
     "status": "pending",
     "submit_time": "2024-03-02T02:39:19.564713178Z",
     "source_code": "int main() { return 0 }"
@@ -225,7 +225,7 @@ Response Body:
     "user_id": 1,
     "problem_id": 1,
     "time_elapsed": 0,
-    "language": "C++",
+    "language_id": 1,
     "status": "failed",
     "failed_test_case_id": 2,
     "submit_time": "2024-03-02T02:45:09.603556Z",

--- a/src/data-layer/init_test_data.sql
+++ b/src/data-layer/init_test_data.sql
@@ -20,7 +20,7 @@ VALUES
 (2,     '2 1',      '3'),
 (2,     '10 10',    '20');
 
-INSERT INTO "submission" (user_id, problem_id, time_elapsed, language, status, failed_test_case_id, submit_time, source_code)
+INSERT INTO "submission" (user_id, problem_id, time_elapsed, language_id, status, failed_test_case_id, submit_time, source_code)
 VALUES
-(1,     1,  2,  'C++',  'compile_error',    NULL,   timestamp '2024-03-07 10:00:00',    'int main2(){}'),
-(2,     2,  2,  'C++',  'failed',           3,      timestamp '2024-03-08 10:00:00',    'int main(){ return 0; }');
+(1,     1,  2,  2,  'compile_error',    NULL,   timestamp '2024-03-07 10:00:00',    'int main2(){}'),
+(2,     2,  2,  1,  'failed',           3,      timestamp '2024-03-08 10:00:00',    'int main(){ return 0; }');

--- a/src/data-layer/main.go
+++ b/src/data-layer/main.go
@@ -39,6 +39,7 @@ func main() {
 	})
 	mux.Use(c.Handler)
 
+	// TODO: Add automated API tests
 	addUserRoutes(mux)
 	addProblemRoutes(mux)
 	addSubmissionRoutes(mux)

--- a/src/data-layer/models.go
+++ b/src/data-layer/models.go
@@ -31,7 +31,7 @@ type Submission struct {
 	UserID           int       `json:"user_id"`
 	ProblemID        int       `json:"problem_id"`
 	TimeElapsed      int       `json:"time_elapsed"`
-	Language         string    `json:"language"`
+	LanguageID       int       `json:"language_id"`
 	Status           string    `json:"status"`
 	FailedTestCaseID *int      `json:"failed_test_case_id,omitempty"`
 	SubmitTime       time.Time `json:"submit_time"`

--- a/src/data-layer/nextjudge.sql
+++ b/src/data-layer/nextjudge.sql
@@ -20,7 +20,7 @@ CREATE TABLE "submission" (
   "user_id" integer,
   "problem_id" integer,
   "time_elapsed" integer,
-  "language" varchar,
+  "language_id" integer,
   "status" varchar,
   "failed_test_case_id" integer,
   "submit_time" timestamp,
@@ -67,6 +67,8 @@ ALTER TABLE "problem" ADD FOREIGN KEY ("user_id") REFERENCES "user" ("id");
 ALTER TABLE "submission" ADD FOREIGN KEY ("user_id") REFERENCES "user" ("id");
 
 ALTER TABLE "submission" ADD FOREIGN KEY ("problem_id") REFERENCES "problem" ("id");
+
+ALTER TABLE "submission" ADD FOREIGN KEY ("language_id") REFERENCES "language" ("id");
 
 ALTER TABLE "test_case" ADD FOREIGN KEY ("problem_id") REFERENCES "problem" ("id");
 

--- a/src/data-layer/problems.go
+++ b/src/data-layer/problems.go
@@ -129,9 +129,7 @@ func getProblem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, testCase := range testCases {
-		problem.TestCases = append(problem.TestCases, *testCase)
-	}
+	problem.TestCases = append(problem.TestCases, testCases...)
 
 	respJSON, err := json.Marshal(problem)
 	if err != nil {
@@ -160,9 +158,7 @@ func getProblems(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		for _, testCase := range testCases {
-			problems[i].TestCases = append(problems[i].TestCases, *testCase)
-		}
+		problems[i].TestCases = append(problems[i].TestCases, testCases...)
 	}
 	respJSON, err := json.Marshal(problems)
 	if err != nil {


### PR DESCRIPTION
This PR replaces `language` on the submissions objects with `language_id`, a foreign key to the languages table