### PR TITLE
fix(tooling): use relative paths for docker-compose stack

### DIFF
--- a/compose/docker-compose.backend.yml
+++ b/compose/docker-compose.backend.yml
@@ -2,7 +2,7 @@ services:
 
   nextjudge-data-layer:
     extends:
-      file: src/data-layer/docker-compose.go.yml
+      file: ../src/data-layer/docker-compose.go.yml
       service: nextjudge-data-layer
     environment:
       - ELASTIC_ENDPOINT=http://elasticsearch:9200
@@ -24,14 +24,14 @@ services:
       #   condition: service_healthy
   db:
     extends:
-      file: src/data-layer/docker-compose.db.yml
+      file: ../src/data-layer/docker-compose.db.yml
       service: db
     environment:
       - POSTGRES_PASSWORD=${AUTH_PROVIDER_PASSWORD}
 
   nextjudge-judge:
     extends:
-      file: src/judge/docker-compose.yml
+      file: ../src/judge/docker-compose.yml
       service: nextjudge-judge
     environment:
       - RABBITMQ_HOST=rabbitmq
@@ -50,7 +50,7 @@ services:
 
   rabbitmq:
     extends:
-      file: src/data-layer/docker-compose.rabbitmq.yml
+      file: ../src/data-layer/docker-compose.rabbitmq.yml
       service: rabbitmq
     environment:
       - RABBITMQ_LOGS="error"

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -2,7 +2,7 @@ services:
 
   nextjudge-data-layer-dev:
     extends:
-      file: src/data-layer/docker-compose.dev.yml
+      file: ../src/data-layer/docker-compose.dev.yml
       service: nextjudge-data-layer-dev
     environment:
       - ELASTIC_ENDPOINT=http://elasticsearch:9200
@@ -27,14 +27,14 @@ services:
 
   db-dev:
     extends:
-      file: src/data-layer/docker-compose.db.yml
+      file: ../src/data-layer/docker-compose.db.yml
       service: db
     environment:
       - POSTGRES_PASSWORD=${AUTH_PROVIDER_PASSWORD}
 
   nextjudge-judge-dev:
     extends:
-      file: src/judge/docker-compose.dev.yml
+      file: ../src/judge/docker-compose.dev.yml
       service: nextjudge-judge-dev
     environment:
       - RABBITMQ_HOST=rabbitmq-dev
@@ -53,7 +53,7 @@ services:
 
   rabbitmq-dev:
     extends:
-      file: src/data-layer/docker-compose.rabbitmq.yml
+      file: ../src/data-layer/docker-compose.rabbitmq.yml
       service: rabbitmq
     environment:
       - RABBITMQ_LOGS="error"

--- a/compose/docker-compose.prebuilt.yml
+++ b/compose/docker-compose.prebuilt.yml
@@ -21,7 +21,7 @@ services:
       #   condition: service_healthy
   db:
     extends:
-      file: src/data-layer/docker-compose.db.yml
+      file: ../src/data-layer/docker-compose.db.yml
       service: db
     environment:
       - POSTGRES_PASSWORD=${AUTH_PROVIDER_PASSWORD}
@@ -49,7 +49,7 @@ services:
 
   rabbitmq:
     extends:
-      file: src/data-layer/docker-compose.rabbitmq.yml
+      file: ../src/data-layer/docker-compose.rabbitmq.yml
       service: rabbitmq
     environment:
       - RABBITMQ_LOGS="error"


### PR DESCRIPTION
this makes `./dev-deploy.sh` work again 