### PR TITLE
Render architecture.png

### DIFF
--- a/src/docs/src/content/docs/architecture/components.md
+++ b/src/docs/src/content/docs/architecture/components.md
@@ -9,7 +9,7 @@ NextJudge follows a distributed architecture composed of a number of components/
 
 The following diagram shows the current architecture of NextJudge:
 
-![Architecture](/src/assets/architecture.png)
+![Architecture](/architecture.png)
 
 ## Components
 


### PR DESCRIPTION
md file doesn't resolve images correctly on deployment. This was most likely not caught before since Vite serves the filesystem in dev mode.

`bun run preview` before

<img width="791" height="381" alt="image" src="https://github.com/user-attachments/assets/a2589968-c33c-4c12-a4e8-238e83da9212" />


`bun run preview` after

<img width="822" height="826" alt="image" src="https://github.com/user-attachments/assets/e91887ff-e373-4589-b5fe-9e027aa55739" />

Not too familiar with astro system, but my understanding is `public/` image is not optimized. Please let me know if I should look into making it work with existing setup
