### PR TITLE
feat(web): redesign problem editor with reliable submission enqueue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,8 @@ jobs:
         working-directory: src/judge
         run: |
           docker build -f Dockerfile.newbase --target prod -t basejudge:prod .
-          docker build -f Dockerfile.monolith --build-arg BASEJUDGE=basejudge:prod -t nextjudge-judge-test .
-          docker compose -f docker-compose.test.yml run --rm --build pytest
+          docker build -f Dockerfile.monolith --target test --build-arg BASEJUDGE=basejudge:prod -t nextjudge-judge-test .
+          docker compose -f docker-compose.test.yml run --rm pytest
 
   ci-success:
     needs: [changes, web-lint, web-build, docs-build, backend-build, judge-tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,11 @@ jobs:
 
   preview-deploy:
     needs: [changes, ci-success]
+    # always() is required when ci-success ran via always() with skipped jobs
+    # (e.g. docs-build). Otherwise preview-deploy is skipped even when web changed.
     if: |
+      always() &&
+      needs.ci-success.result == 'success' &&
       github.event_name == 'pull_request' &&
       (
         needs.changes.outputs.web == 'true' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           docker build -f Dockerfile.newbase --target prod -t basejudge:prod .
           docker build -f Dockerfile.monolith --build-arg BASEJUDGE=basejudge:prod -t nextjudge-judge-test .
-          docker compose -f docker-compose.test.yml run --rm pytest
+          docker compose -f docker-compose.test.yml run --rm --build pytest
 
   ci-success:
     needs: [changes, web-lint, web-build, docs-build, backend-build, judge-tests]

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ src/data-layer/Pipfile.lock
 .vercel
 .env.coolify
 coolify.env
-
+tsconfig.tsbuildinfo
 presentation/

--- a/src/data-layer/src/database.go
+++ b/src/data-layer/src/database.go
@@ -380,6 +380,7 @@ func (d *Database) DeleteProblem(problem *ProblemDescriptionExt) error {
 
 func (d *Database) CreateSubmission(submission *Submission) (*Submission, error) {
 	submission.SubmitTime = time.Now()
+	submission.EnqueueState = EnqueuePending
 	err := d.NextJudgeDB.Create(submission).Error
 	if err != nil {
 		return nil, err

--- a/src/data-layer/src/database_enqueue.go
+++ b/src/data-layer/src/database_enqueue.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const (
+	maxEnqueueAttempts   = 20
+	staleQueuedThreshold = 5 * time.Minute
+)
+
+func (d *Database) CreateInputSubmission(submission *InputSubmission) (*InputSubmission, error) {
+	submission.CreatedAt = time.Now()
+	submission.EnqueueState = EnqueuePending
+	err := d.NextJudgeDB.Create(submission).Error
+	if err != nil {
+		return nil, err
+	}
+	return submission, nil
+}
+
+func (d *Database) GetInputSubmission(submissionID uuid.UUID) (*InputSubmission, error) {
+	submission := &InputSubmission{}
+	err := d.NextJudgeDB.First(submission, submissionID).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return submission, nil
+}
+
+func (d *Database) UpdateInputSubmissionResult(submission *InputSubmission) error {
+	return d.NextJudgeDB.Model(submission).Select(
+		"status",
+		"stdout",
+		"stderr",
+		"runtime",
+		"finished",
+	).Updates(submission).Error
+}
+
+func (d *Database) MarkSubmissionEnqueued(submissionID uuid.UUID) error {
+	now := time.Now()
+	return d.NextJudgeDB.Model(&Submission{}).
+		Where("id = ?", submissionID).
+		Updates(map[string]interface{}{
+			"enqueue_state": EnqueueQueued,
+			"enqueued_at":   now,
+		}).Error
+}
+
+func (d *Database) IncrementSubmissionEnqueueAttempt(submissionID uuid.UUID) error {
+	return d.NextJudgeDB.Model(&Submission{}).
+		Where("id = ?", submissionID).
+		UpdateColumn("enqueue_attempts", gorm.Expr("enqueue_attempts + 1")).Error
+}
+
+func (d *Database) MarkSubmissionEnqueueFailed(submissionID uuid.UUID) error {
+	return d.NextJudgeDB.Model(&Submission{}).
+		Where("id = ?", submissionID).
+		Update("enqueue_state", EnqueueFailed).Error
+}
+
+func (d *Database) MarkInputSubmissionEnqueued(submissionID uuid.UUID) error {
+	now := time.Now()
+	return d.NextJudgeDB.Model(&InputSubmission{}).
+		Where("id = ?", submissionID).
+		Updates(map[string]interface{}{
+			"enqueue_state": EnqueueQueued,
+			"enqueued_at":   now,
+		}).Error
+}
+
+func (d *Database) IncrementInputSubmissionEnqueueAttempt(submissionID uuid.UUID) error {
+	return d.NextJudgeDB.Model(&InputSubmission{}).
+		Where("id = ?", submissionID).
+		UpdateColumn("enqueue_attempts", gorm.Expr("enqueue_attempts + 1")).Error
+}
+
+func (d *Database) MarkInputSubmissionEnqueueFailed(submissionID uuid.UUID) error {
+	return d.NextJudgeDB.Model(&InputSubmission{}).
+		Where("id = ?", submissionID).
+		Update("enqueue_state", EnqueueFailed).Error
+}
+
+func (d *Database) ListSubmissionsNeedingEnqueue(limit int) ([]Submission, error) {
+	cutoff := time.Now().Add(-staleQueuedThreshold)
+	submissions := []Submission{}
+	err := d.NextJudgeDB.
+		Where("status = ?", Pending).
+		Where("enqueue_state IN ?", []EnqueueState{EnqueuePending, EnqueueQueued}).
+		Where("enqueue_attempts < ?", maxEnqueueAttempts).
+		Where("enqueue_state = ? OR enqueued_at IS NULL OR enqueued_at < ?", EnqueuePending, cutoff).
+		Order("submit_time ASC").
+		Limit(limit).
+		Find(&submissions).Error
+	if err != nil {
+		return nil, err
+	}
+	return submissions, nil
+}
+
+func (d *Database) ListInputSubmissionsNeedingEnqueue(limit int) ([]InputSubmission, error) {
+	cutoff := time.Now().Add(-staleQueuedThreshold)
+	submissions := []InputSubmission{}
+	err := d.NextJudgeDB.
+		Where("finished = ?", false).
+		Where("enqueue_state IN ?", []EnqueueState{EnqueuePending, EnqueueQueued}).
+		Where("enqueue_attempts < ?", maxEnqueueAttempts).
+		Where("enqueue_state = ? OR enqueued_at IS NULL OR enqueued_at < ?", EnqueuePending, cutoff).
+		Order("created_at ASC").
+		Limit(limit).
+		Find(&submissions).Error
+	if err != nil {
+		return nil, err
+	}
+	return submissions, nil
+}

--- a/src/data-layer/src/enqueue.go
+++ b/src/data-layer/src/enqueue.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	enqueueReaperInterval = 30 * time.Second
+	enqueueReaperBatchSize  = 50
+)
+
+func StartEnqueueReaper() {
+	go func() {
+		// Run once at startup to drain anything left from a previous crash.
+		processEnqueueBacklog()
+
+		ticker := time.NewTicker(enqueueReaperInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			processEnqueueBacklog()
+		}
+	}()
+}
+
+func processEnqueueBacklog() {
+	if db == nil || rabbitService == nil {
+		return
+	}
+
+	submissions, err := db.ListSubmissionsNeedingEnqueue(enqueueReaperBatchSize)
+	if err != nil {
+		logrus.WithError(err).Error("failed to list submissions needing enqueue")
+		return
+	}
+	for _, submission := range submissions {
+		enqueueProblemSubmission(submission.ID)
+	}
+
+	inputSubmissions, err := db.ListInputSubmissionsNeedingEnqueue(enqueueReaperBatchSize)
+	if err != nil {
+		logrus.WithError(err).Error("failed to list input submissions needing enqueue")
+		return
+	}
+	for _, submission := range inputSubmissions {
+		enqueueInputSubmission(submission.ID)
+	}
+}
+
+func enqueueProblemSubmission(submissionID uuid.UUID) {
+	if err := db.IncrementSubmissionEnqueueAttempt(submissionID); err != nil {
+		logrus.WithError(err).WithField("submission_id", submissionID).Error("failed to increment enqueue attempts")
+		return
+	}
+
+	if err := publishSubmissionMessage(submissionID.String()); err != nil {
+		logrus.WithError(err).WithField("submission_id", submissionID).Warn("failed to publish submission to RabbitMQ")
+
+		submission, getErr := db.GetSubmission(submissionID)
+		if getErr == nil && submission != nil && submission.EnqueueAttempts >= maxEnqueueAttempts {
+			_ = db.MarkSubmissionEnqueueFailed(submissionID)
+		}
+		return
+	}
+
+	if err := db.MarkSubmissionEnqueued(submissionID); err != nil {
+		logrus.WithError(err).WithField("submission_id", submissionID).Error("failed to mark submission as enqueued")
+		return
+	}
+
+	logrus.WithField("submission_id", submissionID).Info("Published problem submission to RabbitMQ")
+}
+
+func enqueueInputSubmission(submissionID uuid.UUID) {
+	if err := db.IncrementInputSubmissionEnqueueAttempt(submissionID); err != nil {
+		logrus.WithError(err).WithField("submission_id", submissionID).Error("failed to increment input enqueue attempts")
+		return
+	}
+
+	if err := publishInputSubmissionMessage(submissionID.String()); err != nil {
+		logrus.WithError(err).WithField("submission_id", submissionID).Warn("failed to publish input submission to RabbitMQ")
+
+		submission, getErr := db.GetInputSubmission(submissionID)
+		if getErr == nil && submission != nil && submission.EnqueueAttempts >= maxEnqueueAttempts {
+			_ = db.MarkInputSubmissionEnqueueFailed(submissionID)
+		}
+		return
+	}
+
+	if err := db.MarkInputSubmissionEnqueued(submissionID); err != nil {
+		logrus.WithError(err).WithField("submission_id", submissionID).Error("failed to mark input submission as enqueued")
+		return
+	}
+
+	logrus.WithField("submission_id", submissionID).Info("Published input submission to RabbitMQ")
+}
+
+func tryEnqueueProblemSubmission(submissionID uuid.UUID) {
+	enqueueProblemSubmission(submissionID)
+}
+
+func tryEnqueueInputSubmission(submissionID uuid.UUID) {
+	enqueueInputSubmission(submissionID)
+}

--- a/src/data-layer/src/inputsubmissions.go
+++ b/src/data-layer/src/inputsubmissions.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -39,44 +38,51 @@ type UpdateCustomInputSubmissionStatusPatchBody struct {
 	Runtime float64 `json:"runtime"`
 }
 
-var customSubmissionMap = make(map[string]*CustomInputSubmissionResult)
-
-// These API endpoints don't touch the database
 func addInputSubmissionRoutes(mux *goji.Mux) {
-	// public endpoints for landing page demo (rate-limited, no auth required)
-	// register these first so they match before the regular routes
 	mux.HandleFunc(pat.Post("/v1/public/input_submissions"), RateLimitMiddleware(postPublicInputSubmission, publicInputLimiter))
-	mux.HandleFunc(pat.Get("/v1/public/input_submissions/:submission_id"), getInputSubmission)
-	// dedicated benchmark endpoints (no rate limiting, header-free)
+	mux.HandleFunc(pat.Get("/v1/public/input_submissions/:submission_id"), getPublicInputSubmission)
+
 	mux.HandleFunc(pat.Post("/v1/bench/input_submissions"), postPublicInputSubmission)
-	mux.HandleFunc(pat.Get("/v1/bench/input_submissions/:submission_id"), getInputSubmission)
+	mux.HandleFunc(pat.Get("/v1/bench/input_submissions/:submission_id"), getPublicInputSubmission)
 
 	mux.HandleFunc(pat.Post("/v1/input_submissions"), AuthRequired(postInputSubmission))
-	mux.HandleFunc(pat.Get("/v1/input_submissions/:submission_id"), AuthRequired(getInputSubmission))
+	mux.HandleFunc(pat.Get("/v1/input_submissions/:submission_id"), AuthRequired(getAuthenticatedInputSubmission))
 	mux.HandleFunc(pat.Patch("/v1/input_submissions/:submission_id"), AtLeastJudgeRequired(updateCustomInputSubmissionStatus))
 }
 
+func createInputSubmissionRecord(reqData *CustomInputSubmissionStatusPostBody) (uuid.UUID, error) {
+	var userID *uuid.UUID
+	if reqData.UserID != uuid.Nil {
+		userID = &reqData.UserID
+	}
+
+	record := &InputSubmission{
+		UserID:     userID,
+		LanguageID: reqData.LanguageID,
+		SourceCode: reqData.SourceCode,
+		Stdin:      reqData.Stdin,
+		Status:     Pending,
+		Finished:   false,
+	}
+
+	created, err := db.CreateInputSubmission(record)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	tryEnqueueInputSubmission(created.ID)
+	return created.ID, nil
+}
+
 func postInputSubmission(w http.ResponseWriter, r *http.Request) {
-	reqData := new(CustomInputSubmissionStatusPostBody)
-	reqBodyBytes, err := io.ReadAll(r.Body)
+	reqData, err := parseInputSubmissionPostBody(r)
 	if err != nil {
-		logrus.WithError(err).Error("error reading request body")
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, `{"code":"500", "message":"error reading request body"}`)
+		writeInputSubmissionError(w, err)
 		return
 	}
 
-	err = json.Unmarshal(reqBodyBytes, reqData)
-	if err != nil {
-		logrus.WithError(err).Error("JSON parse error")
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, `{"code":"500", "message":"JSON parse error"}`)
-		return
-	}
-
-	// User ID boilerplate
-	token := r.Context().Value(ContextTokenKey).(*NextJudgeClaims)
-	if token == nil {
+	token, ok := r.Context().Value(ContextTokenKey).(*NextJudgeClaims)
+	if !ok || token == nil {
 		logrus.Error("Error in token")
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, `{"message":"Error in token"}`)
@@ -84,9 +90,7 @@ func postInputSubmission(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userId := token.Id
-
 	if reqData.UserID != userId && reqData.UserID != uuid.Nil {
-		// Admins can access all users
 		if token.Role == AdminRoleEnum {
 			userId = reqData.UserID
 		} else {
@@ -96,111 +100,168 @@ func postInputSubmission(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-
 	reqData.UserID = userId
 
-	new_uuid := uuid.New()
-
-	status_object := CustomInputSubmissionResult{
-		Finished: false,
+	submissionID, err := createInputSubmissionRecord(reqData)
+	if err != nil {
+		logrus.WithError(err).Error("error creating input submission")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"code":"500", "message":"error creating input submission"}`)
+		return
 	}
 
-	customSubmissionMap[new_uuid.String()] = &status_object
-
-	RabbitMQPublishCustomInputSubmission(new_uuid.String(), reqData)
-
-	fmt.Fprint(w, new_uuid.String())
+	fmt.Fprint(w, submissionID.String())
 }
 
-// postPublicInputSubmission handles public (unauthenticated) code execution for landing page demo
 func postPublicInputSubmission(w http.ResponseWriter, r *http.Request) {
+	reqData, err := parseInputSubmissionPostBody(r)
+	if err != nil {
+		writeInputSubmissionError(w, err)
+		return
+	}
+
+	reqData.UserID = uuid.Nil
+
+	submissionID, err := createInputSubmissionRecord(reqData)
+	if err != nil {
+		logrus.WithError(err).Error("error creating public input submission")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"code":"500", "message":"error creating input submission"}`)
+		return
+	}
+
+	fmt.Fprint(w, submissionID.String())
+}
+
+func parseInputSubmissionPostBody(r *http.Request) (*CustomInputSubmissionStatusPostBody, error) {
 	reqData := new(CustomInputSubmissionStatusPostBody)
 	reqBodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		logrus.WithError(err).Error("error reading request body")
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, `{"code":"500", "message":"error reading request body"}`)
-		return
+		return nil, err
 	}
-
-	err = json.Unmarshal(reqBodyBytes, reqData)
-	if err != nil {
-		logrus.WithError(err).Error("JSON parse error")
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, `{"code":"500", "message":"JSON parse error"}`)
-		return
+	if err := json.Unmarshal(reqBodyBytes, reqData); err != nil {
+		return nil, err
 	}
-
-	// use a nil UUID for anonymous submissions
-	reqData.UserID = uuid.Nil
-
-	new_uuid := uuid.New()
-
-	status_object := CustomInputSubmissionResult{
-		Finished: false,
-	}
-
-	customSubmissionMap[new_uuid.String()] = &status_object
-
-	RabbitMQPublishCustomInputSubmission(new_uuid.String(), reqData)
-
-	fmt.Fprint(w, new_uuid.String())
+	return reqData, nil
 }
 
-func getInputSubmission(w http.ResponseWriter, r *http.Request) {
+func writeInputSubmissionError(w http.ResponseWriter, err error) {
+	logrus.WithError(err).Error("input submission request error")
+	w.WriteHeader(http.StatusInternalServerError)
+	fmt.Fprint(w, `{"code":"500", "message":"error processing request"}`)
+}
+
+func getPublicInputSubmission(w http.ResponseWriter, r *http.Request) {
+	submission, ok := loadInputSubmissionFromRequest(w, r)
+	if !ok {
+		return
+	}
+	writeInputSubmissionPollResponse(w, submission, false)
+}
+
+func getAuthenticatedInputSubmission(w http.ResponseWriter, r *http.Request) {
+	submission, ok := loadInputSubmissionFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	token, ok := r.Context().Value(ContextTokenKey).(*NextJudgeClaims)
+	if !ok || token == nil {
+		logrus.Error("Error in token")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"message":"Error in token"}`)
+		return
+	}
+
+	if token.Role >= JudgeRoleEnum {
+		writeInputSubmissionPollResponse(w, submission, true)
+		return
+	}
+
+	if submission.UserID != nil && *submission.UserID != token.Id {
+		logrus.Error("Unauthorized get input submission")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"message":"Unauthorized"}`)
+		return
+	}
+
+	writeInputSubmissionPollResponse(w, submission, false)
+}
+
+func loadInputSubmissionFromRequest(w http.ResponseWriter, r *http.Request) (*InputSubmission, bool) {
 	submissionIdParam := pat.Param(r, "submission_id")
 	submissionId, err := uuid.Parse(submissionIdParam)
 	if err != nil {
 		logrus.Warn("bad uuid")
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, `{"code":"400", "message":"bad uuid"}`)
-		return
+		return nil, false
 	}
 
-	result, ok := customSubmissionMap[submissionId.String()]
-	if !ok {
+	submission, err := db.GetInputSubmission(submissionId)
+	if err != nil {
+		logrus.WithError(err).Error("error retrieving input submission")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"code":"500", "message":"error retrieving input submission"}`)
+		return nil, false
+	}
+	if submission == nil {
 		logrus.Warn("submission not found")
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"code":"404", "message":"submission not found"}`)
-		return
-	} else {
-		if !result.Finished {
-
-			return_data := CustomInputSubmissionResultStatus{
-				Status: "PENDING",
-			}
-
-			json_data, err := json.Marshal(return_data)
-			if err != nil {
-				log.Fatal(err)
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprint(w, `{"code":"500", "message":"JSON parse error"}`)
-				return
-			}
-
-			fmt.Fprint(w, string(json_data))
-		} else {
-			logrus.WithFields(logrus.Fields{
-				"submission_id": submissionId.String(),
-				"status":        result.Status,
-				"runtime":       result.Runtime,
-				"finished":      result.Finished,
-			}).Info("returning custom input submission result")
-
-			json_data, err := json.Marshal(result)
-			if err != nil {
-				log.Fatal(err)
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprint(w, `{"code":"500", "message":"JSON parse error"}`)
-				return
-			}
-
-			// Remove the entry from the map
-			delete(customSubmissionMap, submissionId.String())
-
-			fmt.Fprint(w, string(json_data))
-		}
+		return nil, false
 	}
+	return submission, true
+}
+
+func writeInputSubmissionPollResponse(w http.ResponseWriter, submission *InputSubmission, includeJudgeFields bool) {
+	if includeJudgeFields {
+		respJSON, err := json.Marshal(submission)
+		if err != nil {
+			logrus.WithError(err).Error("JSON parse error")
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"code":"500", "message":"JSON parse error"}`)
+			return
+		}
+		fmt.Fprint(w, string(respJSON))
+		return
+	}
+
+	if !submission.Finished {
+		returnData := CustomInputSubmissionResultStatus{Status: "PENDING"}
+		respJSON, err := json.Marshal(returnData)
+		if err != nil {
+			logrus.WithError(err).Error("JSON parse error")
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"code":"500", "message":"JSON parse error"}`)
+			return
+		}
+		fmt.Fprint(w, string(respJSON))
+		return
+	}
+
+	result := CustomInputSubmissionResult{
+		Status:   submission.Status,
+		Stdout:   submission.Stdout,
+		Stderr:   submission.Stderr,
+		Finished: true,
+		Runtime:  submission.Runtime,
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"submission_id": submission.ID,
+		"status":        result.Status,
+		"runtime":       result.Runtime,
+	}).Info("returning custom input submission result")
+
+	respJSON, err := json.Marshal(result)
+	if err != nil {
+		logrus.WithError(err).Error("JSON parse error")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"code":"500", "message":"JSON parse error"}`)
+		return
+	}
+	fmt.Fprint(w, string(respJSON))
 }
 
 func updateCustomInputSubmissionStatus(w http.ResponseWriter, r *http.Request) {
@@ -227,41 +288,50 @@ func updateCustomInputSubmissionStatus(w http.ResponseWriter, r *http.Request) {
 		"raw_body":      string(reqBodyBytes),
 	}).Info("received custom input submission update request")
 
-	err = json.Unmarshal(reqBodyBytes, reqData)
-	if err != nil {
+	if err := json.Unmarshal(reqBodyBytes, reqData); err != nil {
 		logrus.WithError(err).Error("JSON parse error")
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, `{"code":"500", "message":"JSON parse error"}`)
 		return
 	}
 
-	logrus.WithFields(logrus.Fields{
-		"submission_id": submissionId.String(),
-		"status":        reqData.Status,
-		"runtime":       reqData.Runtime,
-		"stdout_length": len(reqData.Stdout),
-		"stderr_length": len(reqData.Stderr),
-	}).Info("parsed custom input submission update data")
-
-	result, ok := customSubmissionMap[submissionId.String()]
-	if !ok {
+	submission, err := db.GetInputSubmission(submissionId)
+	if err != nil {
+		logrus.WithError(err).Error("error retrieving input submission")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"code":"500", "message":"error retrieving input submission"}`)
+		return
+	}
+	if submission == nil {
 		logrus.WithField("submission_id", submissionId.String()).Warn("submission not found")
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"code":"404", "message":"submission not found"}`)
 		return
-	} else {
-		result.Finished = true
-		result.Status = reqData.Status
-		result.Stdout = reqData.Stdout
-		result.Stderr = reqData.Stderr
-		result.Runtime = reqData.Runtime
-
-		logrus.WithFields(logrus.Fields{
-			"submission_id": submissionId.String(),
-			"status":        result.Status,
-			"runtime":       result.Runtime,
-			"finished":      result.Finished,
-		}).Info("updated custom input submission result")
 	}
 
+	if submission.Finished {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	submission.Finished = true
+	submission.Status = reqData.Status
+	submission.Stdout = reqData.Stdout
+	submission.Stderr = reqData.Stderr
+	submission.Runtime = reqData.Runtime
+
+	if err := db.UpdateInputSubmissionResult(submission); err != nil {
+		logrus.WithError(err).Error("error updating input submission")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"code":"500", "message":"error updating input submission"}`)
+		return
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"submission_id": submissionId.String(),
+		"status":        submission.Status,
+		"runtime":       submission.Runtime,
+	}).Info("updated custom input submission result")
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/src/data-layer/src/main.go
+++ b/src/data-layer/src/main.go
@@ -59,6 +59,8 @@ func main() {
 		}
 	}
 
+	StartEnqueueReaper()
+
 	if cfg.ElasticEnabled {
 		es, err = NewElasticSearch()
 		if err != nil {

--- a/src/data-layer/src/migrate.go
+++ b/src/data-layer/src/migrate.go
@@ -10,6 +10,9 @@ import (
 //go:embed nextjudge.sql
 var schemaSQL string
 
+//go:embed schema_updates.sql
+var schemaUpdatesSQL string
+
 //go:embed init_prod_data.sql
 var seedSQL string
 
@@ -24,6 +27,7 @@ func RunMigrations(database *Database) error {
 		"problem_descriptions",
 		"submissions",
 		"submission_test_case_results",
+		"input_submissions",
 		"test_cases",
 		"languages",
 		"categories",
@@ -74,6 +78,10 @@ func RunMigrations(database *Database) error {
 		logrus.Info("All expected tables exist, skipping schema migration")
 	}
 
+	if err := applySchemaUpdates(database); err != nil {
+		return err
+	}
+
 	// check if languages are seeded
 	var langCount int64
 	err := database.NextJudgeDB.Raw("SELECT COUNT(*) FROM languages").Scan(&langCount).Error
@@ -99,5 +107,15 @@ func RunMigrations(database *Database) error {
 		logrus.Infof("Found %d languages, skipping essential data seeding", langCount)
 	}
 
+	return nil
+}
+
+func applySchemaUpdates(database *Database) error {
+	logrus.Info("Applying incremental schema updates...")
+	if err := database.NextJudgeDB.Exec(schemaUpdatesSQL).Error; err != nil {
+		logrus.WithError(err).Error("failed to apply schema updates")
+		return err
+	}
+	logrus.Info("Schema updates applied successfully")
 	return nil
 }

--- a/src/data-layer/src/models.go
+++ b/src/data-layer/src/models.go
@@ -6,6 +6,14 @@ import (
 	"github.com/google/uuid"
 )
 
+type EnqueueState string
+
+const (
+	EnqueuePending EnqueueState = "pending"
+	EnqueueQueued  EnqueueState = "queued"
+	EnqueueFailed  EnqueueState = "failed"
+)
+
 type Status string
 
 const (
@@ -148,6 +156,30 @@ type Submission struct {
 	Stderr           string     `json:"stderr"`
 	// per-test-case results stored in separate table
 	TestCaseResults []SubmissionTestCaseResult `json:"test_case_results,omitempty" gorm:"foreignKey:SubmissionID"`
+	EnqueueState    EnqueueState               `json:"enqueue_state" gorm:"type:enqueue_state;not null;default:pending"`
+	EnqueuedAt      *time.Time                 `json:"enqueued_at,omitempty"`
+	EnqueueAttempts int                        `json:"enqueue_attempts" gorm:"not null;default:0"`
+}
+
+type InputSubmission struct {
+	ID              uuid.UUID    `json:"id" gorm:"type:uuid;default:uuid_generate_v4()"`
+	UserID          *uuid.UUID   `json:"user_id,omitempty"`
+	LanguageID      uuid.UUID    `json:"language_id"`
+	SourceCode      string       `json:"source_code"`
+	Stdin           string       `json:"stdin"`
+	Status          Status       `json:"status"`
+	Stdout          string       `json:"stdout"`
+	Stderr          string       `json:"stderr"`
+	Runtime         float64      `json:"runtime"`
+	Finished        bool         `json:"finished"`
+	CreatedAt       time.Time    `json:"created_at"`
+	EnqueueState    EnqueueState `json:"enqueue_state" gorm:"type:enqueue_state;not null;default:pending"`
+	EnqueuedAt      *time.Time   `json:"enqueued_at,omitempty"`
+	EnqueueAttempts int          `json:"enqueue_attempts" gorm:"not null;default:0"`
+}
+
+func (InputSubmission) TableName() string {
+	return "input_submissions"
 }
 
 type Language struct {

--- a/src/data-layer/src/nextjudge.sql
+++ b/src/data-layer/src/nextjudge.sql
@@ -24,6 +24,12 @@ CREATE TYPE FEEDBACK_POLICY as ENUM(
   'FIRST_ERROR'
 );
 
+CREATE TYPE enqueue_state AS ENUM(
+  'pending',
+  'queued',
+  'failed'
+);
+
 CREATE TABLE "users" (
   "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   "account_identifier" varchar(255) NOT NULL UNIQUE,
@@ -71,7 +77,27 @@ CREATE TABLE "submissions" (
   "submit_time" timestamp NOT NULL,
   "source_code" varchar NOT NULL,
   "stdout" varchar,
-  "stderr" varchar
+  "stderr" varchar,
+  "enqueue_state" enqueue_state NOT NULL DEFAULT 'pending',
+  "enqueued_at" TIMESTAMPTZ,
+  "enqueue_attempts" integer NOT NULL DEFAULT 0
+);
+
+CREATE TABLE "input_submissions" (
+  "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "user_id" UUID,
+  "language_id" UUID NOT NULL,
+  "source_code" TEXT NOT NULL,
+  "stdin" TEXT NOT NULL DEFAULT '',
+  "status" status NOT NULL DEFAULT 'PENDING',
+  "stdout" TEXT,
+  "stderr" TEXT,
+  "runtime" FLOAT NOT NULL DEFAULT 0,
+  "finished" BOOLEAN NOT NULL DEFAULT false,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "enqueue_state" enqueue_state NOT NULL DEFAULT 'pending',
+  "enqueued_at" TIMESTAMPTZ,
+  "enqueue_attempts" integer NOT NULL DEFAULT 0
 );
 
 CREATE TABLE "submission_test_case_results" (
@@ -205,6 +231,8 @@ ALTER TABLE "submissions" ADD FOREIGN KEY ("event_id") REFERENCES "events" ("id"
 ALTER TABLE "submissions" ADD FOREIGN KEY ("event_problem_id") REFERENCES "event_problems" ("id") ON DELETE CASCADE;
 
 ALTER TABLE "submissions" ADD FOREIGN KEY ("language_id") REFERENCES "languages" ("id") ON DELETE CASCADE;
+
+ALTER TABLE "input_submissions" ADD FOREIGN KEY ("language_id") REFERENCES "languages" ("id") ON DELETE CASCADE;
 
 ALTER TABLE "submissions" ADD FOREIGN KEY ("failed_test_case_id") REFERENCES "test_cases" ("id") ON DELETE CASCADE;
 

--- a/src/data-layer/src/rabbit.go
+++ b/src/data-layer/src/rabbit.go
@@ -3,22 +3,28 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/url"
+	"sync"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/sirupsen/logrus"
 )
 
-const SUBMISSION_KEY string = "submission_queue"
+const (
+	SUBMISSION_KEY    = "submission_queue"
+	submissionDLQKey  = "submission_queue.dlq"
+	publishMaxRetries = 3
+)
 
 type RabbitMQService struct {
-	Channel *amqp.Channel
-	Queue   *amqp.Queue
+	mu        sync.Mutex
+	conn      *amqp.Connection
+	channel   *amqp.Channel
+	queueName string
 }
 
-var rabbit_connection *RabbitMQService
+var rabbitService *RabbitMQService
 
 type RabbitMQSubmission struct {
 	Type string `json:"type"`
@@ -26,123 +32,175 @@ type RabbitMQSubmission struct {
 }
 
 type RabbitMQCustomInputSubmission struct {
-	Type       string `json:"type"`
-	Id         string `json:"id"`
-	Code       string `json:"code"`
-	LanguageID string `json:"language_id"`
-	Stdin      string `json:"stdin"`
+	Type string `json:"type"`
+	Id   string `json:"id"`
 }
 
 func SetupRabbitMQConnection() error {
+	rabbitService = &RabbitMQService{}
+	return rabbitService.connect()
+}
 
-	rabbitMQEndpoint := fmt.Sprintf("amqp://%s:%s@%s:5672", url.QueryEscape(cfg.RabbitUser), url.QueryEscape(cfg.RabbitPassword), cfg.RabbitMQHost)
+func (r *RabbitMQService) connect() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.channel != nil {
+		_ = r.channel.Close()
+		r.channel = nil
+	}
+	if r.conn != nil {
+		_ = r.conn.Close()
+		r.conn = nil
+	}
+
+	rabbitMQEndpoint := fmt.Sprintf(
+		"amqp://%s:%s@%s:5672/",
+		url.QueryEscape(cfg.RabbitUser),
+		url.QueryEscape(cfg.RabbitPassword),
+		cfg.RabbitMQHost,
+	)
 
 	var conn *amqp.Connection
 	var err error
-	const MAX_ATTEMPTS = 10
-	attempts := 0
-
-	for conn == nil {
-		conn, err = amqp.Dial(
-			rabbitMQEndpoint,
-		)
-
-		if err != nil {
-			if attempts < MAX_ATTEMPTS {
-				time.Sleep(2 * time.Second)
-			} else {
-				return err
-			}
+	const maxAttempts = 10
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		conn, err = amqp.Dial(rabbitMQEndpoint)
+		if err == nil {
+			break
 		}
-		attempts += 1
+		if attempt < maxAttempts-1 {
+			time.Sleep(2 * time.Second)
+		}
+	}
+	if err != nil {
+		return err
 	}
 
 	channel, err := conn.Channel()
 	if err != nil {
+		_ = conn.Close()
 		return err
 	}
 
-	submission_queue, err := channel.QueueDeclare(
-		SUBMISSION_KEY, // name
-		true,           // durable
-		false,          // delete when unused
-		false,          // exclusive
-		false,          // no-wait
-		nil,            // arguments
+	queue, err := channel.QueueDeclare(
+		SUBMISSION_KEY,
+		true,
+		false,
+		false,
+		false,
+		nil,
 	)
 	if err != nil {
+		_ = channel.Close()
+		_ = conn.Close()
 		return err
 	}
 
-	rabbit_connection = &RabbitMQService{
-		channel,
-		&submission_queue,
+	_, err = channel.QueueDeclare(
+		submissionDLQKey,
+		true,
+		false,
+		false,
+		false,
+		nil,
+	)
+	if err != nil {
+		_ = channel.Close()
+		_ = conn.Close()
+		return err
 	}
 
+	r.conn = conn
+	r.channel = channel
+	r.queueName = queue.Name
 	return nil
 }
 
-func RabbitMQPublishSubmission(id string) {
+func (r *RabbitMQService) reconnect() error {
+	logrus.Warn("Reconnecting to RabbitMQ...")
+	return r.connect()
+}
+
+func (r *RabbitMQService) publish(body []byte) error {
+	var lastErr error
+	for attempt := 0; attempt < publishMaxRetries; attempt++ {
+		r.mu.Lock()
+		channel := r.channel
+		queueName := r.queueName
+		r.mu.Unlock()
+
+		if channel == nil {
+			if err := r.reconnect(); err != nil {
+				lastErr = err
+				time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+				continue
+			}
+			r.mu.Lock()
+			channel = r.channel
+			queueName = r.queueName
+			r.mu.Unlock()
+		}
+
+		err := channel.Publish(
+			"",
+			queueName,
+			false,
+			false,
+			amqp.Publishing{
+				ContentType:  "application/json",
+				Body:         body,
+				DeliveryMode: amqp.Persistent,
+			},
+		)
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+		logrus.WithError(err).Warn("RabbitMQ publish failed, reconnecting")
+		if reconnectErr := r.reconnect(); reconnectErr != nil {
+			lastErr = reconnectErr
+		}
+		time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+	}
+	return lastErr
+}
+
+func publishSubmissionMessage(id string) error {
 	data := RabbitMQSubmission{
 		Type: "submission",
 		Id:   id,
 	}
-
-	json_data, err := json.Marshal(data)
+	jsonData, err := json.Marshal(data)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
-
-	err = rabbit_connection.Channel.Publish(
-		"",                           // exchange
-		rabbit_connection.Queue.Name, // routing key
-		false,                        // mandatory
-		false,                        // immediate
-		amqp.Publishing{
-			ContentType: "text/plain",
-			Body:        []byte(json_data),
-		},
-	)
-
-	if err != nil {
-		logrus.Fatal(err)
-	}
-
-	log.Println("Published")
+	return rabbitService.publish(jsonData)
 }
 
-func RabbitMQPublishCustomInputSubmission(id string, body *CustomInputSubmissionStatusPostBody) {
+func publishInputSubmissionMessage(id string) error {
 	data := RabbitMQCustomInputSubmission{
-		Type:       "input",
-		Id:         id,
-		Code:       body.SourceCode,
-		LanguageID: body.LanguageID.String(),
-		Stdin:      body.Stdin,
+		Type: "input",
+		Id:   id,
 	}
-
-	json_data, err := json.Marshal(data)
+	jsonData, err := json.Marshal(data)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
-
-	err = rabbit_connection.Channel.Publish(
-		"",                           // exchange
-		rabbit_connection.Queue.Name, // routing key
-		false,                        // mandatory
-		false,                        // immediate
-		amqp.Publishing{
-			ContentType: "text/plain",
-			Body:        []byte(json_data),
-		},
-	)
-
-	if err != nil {
-		logrus.Fatal(err)
-	}
-
-	log.Println("Published")
+	return rabbitService.publish(jsonData)
 }
 
 func CloseRabbitMQConnection() {
-	rabbit_connection.Channel.Close()
+	if rabbitService == nil {
+		return
+	}
+	rabbitService.mu.Lock()
+	defer rabbitService.mu.Unlock()
+	if rabbitService.channel != nil {
+		_ = rabbitService.channel.Close()
+	}
+	if rabbitService.conn != nil {
+		_ = rabbitService.conn.Close()
+	}
 }

--- a/src/data-layer/src/schema_updates.sql
+++ b/src/data-layer/src/schema_updates.sql
@@ -1,0 +1,55 @@
+-- Incremental schema updates for existing deployments.
+-- Each statement must be safe to run multiple times.
+
+DO $$ BEGIN
+    CREATE TYPE enqueue_state AS ENUM ('pending', 'queued', 'failed');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE submissions
+    ADD COLUMN IF NOT EXISTS enqueue_state enqueue_state NOT NULL DEFAULT 'queued';
+
+ALTER TABLE submissions
+    ADD COLUMN IF NOT EXISTS enqueued_at TIMESTAMPTZ;
+
+ALTER TABLE submissions
+    ADD COLUMN IF NOT EXISTS enqueue_attempts INT NOT NULL DEFAULT 0;
+
+-- Re-queue any submission that was never judged so the reaper can deliver it.
+UPDATE submissions
+SET enqueue_state = 'pending', enqueue_attempts = 0
+WHERE status = 'PENDING';
+
+CREATE TABLE IF NOT EXISTS input_submissions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID,
+    language_id UUID NOT NULL,
+    source_code TEXT NOT NULL,
+    stdin TEXT NOT NULL DEFAULT '',
+    status status NOT NULL DEFAULT 'PENDING',
+    stdout TEXT,
+    stderr TEXT,
+    runtime FLOAT NOT NULL DEFAULT 0,
+    finished BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    enqueue_state enqueue_state NOT NULL DEFAULT 'pending',
+    enqueued_at TIMESTAMPTZ,
+    enqueue_attempts INT NOT NULL DEFAULT 0
+);
+
+DO $$ BEGIN
+    ALTER TABLE input_submissions
+        ADD CONSTRAINT input_submissions_language_id_fkey
+        FOREIGN KEY (language_id) REFERENCES languages (id) ON DELETE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_submissions_stale_enqueue
+    ON submissions (submit_time)
+    WHERE status = 'PENDING' AND enqueue_state IN ('pending', 'queued');
+
+CREATE INDEX IF NOT EXISTS idx_input_submissions_stale_enqueue
+    ON input_submissions (created_at)
+    WHERE finished = false AND enqueue_state IN ('pending', 'queued');

--- a/src/data-layer/src/submissions.go
+++ b/src/data-layer/src/submissions.go
@@ -240,8 +240,8 @@ func postSubmission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// send submission to judge
-	RabbitMQPublishSubmission(response.ID.String())
+	// send submission to judge (reaper retries if this fails)
+	tryEnqueueProblemSubmission(response.ID)
 
 	w.WriteHeader(http.StatusCreated)
 	fmt.Fprint(w, string(respJSON))

--- a/src/judge/Dockerfile.monolith
+++ b/src/judge/Dockerfile.monolith
@@ -55,9 +55,6 @@ FROM ${BASEJUDGE} AS release
 COPY --from=build / /chroot
 RUN chown -R 99999:99999 /chroot/dev
 
-RUN mkdir -p /go_cache /go_mod_cache && chown 99999:99999 /go_cache /go_mod_cache && \
-    mkdir -p /chroot/go_cache /chroot/go_mod_cache && chown 99999:99999 /chroot/go_cache /chroot/go_mod_cache
-
 COPY languages.toml /app/languages.toml
 
 FROM release AS test

--- a/src/judge/Dockerfile.monolith
+++ b/src/judge/Dockerfile.monolith
@@ -59,3 +59,20 @@ RUN mkdir -p /go_cache /go_mod_cache && chown 99999:99999 /go_cache /go_mod_cach
     mkdir -p /chroot/go_cache /chroot/go_mod_cache && chown 99999:99999 /chroot/go_cache /chroot/go_mod_cache
 
 COPY languages.toml /app/languages.toml
+
+FROM release AS test
+
+WORKDIR /app
+
+RUN mkdir -p /app/src/
+RUN mv /app/languages.toml /app/app.py /app/src/
+RUN touch /app/src/__init__.py
+
+COPY test-requirements.txt ./
+RUN pip install -r test-requirements.txt --break-system-packages
+
+COPY tests ./tests
+RUN touch /app/tests/__init__.py
+
+ENV PYTEST_ADDOPTS="--color=yes"
+ENTRYPOINT [ "pytest", "-v", "-l" ]

--- a/src/judge/Dockerfile.tests
+++ b/src/judge/Dockerfile.tests
@@ -1,3 +1,5 @@
+# Deprecated: build the monolith test target instead.
+#   docker build -f Dockerfile.monolith --target test --build-arg BASEJUDGE=basejudge:prod -t nextjudge-judge-test .
 FROM nextjudge-judge-test
 
 WORKDIR /app

--- a/src/judge/docker-compose.test.yml
+++ b/src/judge/docker-compose.test.yml
@@ -3,3 +3,10 @@ services:
     image: nextjudge-judge-test
     pull_policy: never
     privileged: true
+    volumes:
+      - go_cache:/var/lib/nextjudge/go-cache
+      - go_mod_cache:/var/lib/nextjudge/go-mod
+
+volumes:
+  go_cache:
+  go_mod_cache:

--- a/src/judge/docker-compose.test.yml
+++ b/src/judge/docker-compose.test.yml
@@ -2,7 +2,4 @@ services:
   pytest:
     image: nextjudge-judge-test
     pull_policy: never
-    build:
-      dockerfile: ./Dockerfile.tests
-      context: .
     privileged: true

--- a/src/judge/src/app.py
+++ b/src/judge/src/app.py
@@ -137,6 +137,22 @@ def get_submission_data(submission_id: str):
     print(data)
     return data
 
+def get_input_submission_data(submission_id: str):
+    response = requests.get(
+        f"{NEXTJUDGE_ENDPOINT}/v1/input_submissions/{submission_id}",
+        headers={
+            "Authorization": JUDGE_JWT_TOKEN
+        }
+    )
+    if not response.ok:
+        raise RuntimeError(
+            f"Failed to fetch input submission {submission_id}: "
+            f"status_code={response.status_code}, response={response.text}"
+        )
+    data = response.json()
+    print(data)
+    return data
+
 def get_test_data(problem_id: str):
     """
     Get all tests for a given problem_id
@@ -160,8 +176,12 @@ def post_judgement(submission_id: str, data):
             "Authorization":JUDGE_JWT_TOKEN
         }
     )
-    # print(data)
-    return data
+    if not response.ok:
+        raise RuntimeError(
+            f"Failed to update submission {submission_id}: "
+            f"status_code={response.status_code}, response={response.text}"
+        )
+    return response
 
 def post_custom_input_result(submission_id: str, body):
     print(f"Sending custom input result for submission {submission_id}: status={body.get('status')}, runtime={body.get('runtime')}", flush=True)
@@ -176,9 +196,11 @@ def post_custom_input_result(submission_id: str, body):
     )
 
     if not response.ok:
-        print(f"ERROR: Failed to update custom input submission {submission_id}: status_code={response.status_code}, response={response.text}", flush=True)
-    else:
-        print(f"Successfully updated custom input submission {submission_id} with runtime: {body.get('runtime', 0)}", flush=True)
+        raise RuntimeError(
+            f"Failed to update custom input submission {submission_id}: "
+            f"status_code={response.status_code}, response={response.text}"
+        )
+    print(f"Successfully updated custom input submission {submission_id} with runtime: {body.get('runtime', 0)}", flush=True)
 
 @dataclass
 class Language:
@@ -411,6 +433,10 @@ async def handle_test_submission(submission_id: str):
 
     submission_data = get_submission_data(submission_id)
 
+    if submission_data.get("status") != "PENDING":
+        print(f"Submission {submission_id} already judged ({submission_data.get('status')}), skipping")
+        return
+
     # Get test data for this ID
     # raw_test_data = await rabbitmq.get_test_data(submission_data["problem_id"])
     # test_data = json.loads(raw_test_data)
@@ -431,6 +457,12 @@ async def handle_test_submission(submission_id: str):
     if local_language_id == None:
         print("No such language!")
         environment.remove_files()
+        await submit_judgement(
+            submission_data,
+            "COMPILE_TIME_ERROR",
+            b"",
+            b"unsupported language",
+        )
         return
 
     compile_result = compile_in_jail(submission_data["source_code"], LOCAL_LANGUAGES_MAP[local_language_id], environment)
@@ -481,10 +513,54 @@ async def handle_test_submission(submission_id: str):
     await submit_judgement(submission_data, "ACCEPTED", last_stdout, last_stderr, "-1", test_case_results, total_time_elapsed)
 
 
+async def handle_custom_input_submission(json_data: dict):
+    submission_id = json_data["id"]
+
+    if "code" in json_data:
+        source_code = json_data["code"]
+        language_id = json_data["language_id"]
+        stdin = json_data["stdin"]
+    else:
+        input_data = get_input_submission_data(submission_id)
+        if input_data.get("finished"):
+            print(f"Input submission {submission_id} already finished, skipping")
+            return
+        source_code = input_data["source_code"]
+        language_id = input_data["language_id"]
+        stdin = input_data["stdin"]
+
+    environment = create_program_environment()
+    environment.create_directories()
+
+    local_language_id = BRIDGE_LANG_ID_MAP.get(language_id)
+
+    if local_language_id == None:
+        print("No such language!")
+        environment.remove_files()
+        await submit_custom_input_judgement(submission_id, "RUNTIME_ERROR", b"", b"unsupported language")
+        return
+
+    if not compile_in_jail(source_code, LOCAL_LANGUAGES_MAP[local_language_id], environment).success:
+        environment.remove_files()
+        await submit_custom_input_judgement(submission_id, "COMPILE_TIME_ERROR", b"", b"")
+        return
+
+    language = LOCAL_LANGUAGES_MAP[local_language_id]
+    run_result = run_single(environment, bytes(stdin, "utf-8"), language=language)
+    environment.remove_files()
+
+    await submit_custom_input_judgement(
+        submission_id,
+        run_result.result,
+        run_result.stdout,
+        run_result.stderr,
+        run_result.runtime,
+    )
+
+
 async def handle_submission(message: aio_pika.abc.AbstractIncomingMessage):
 
-    # Requeue the message if we fail, and reject attempts to redeliver it to us
-    async with message.process(requeue=True,reject_on_redelivered=True):
+    async with message.process(requeue=True):
         print(f"Judge received a submission")
         print(message.body)
 
@@ -495,31 +571,7 @@ async def handle_submission(message: aio_pika.abc.AbstractIncomingMessage):
             submission_id = json_data["id"]
             await handle_test_submission(submission_id)
         elif work_item_type == "input":
-            source_code = json_data["code"]
-            language_id = json_data["language_id"]
-            stdin = json_data["stdin"]
-
-            environment = create_program_environment()
-            environment.create_directories()
-
-            local_language_id = BRIDGE_LANG_ID_MAP.get(language_id)
-
-            if local_language_id == None:
-                print("No such language!")
-                environment.remove_files()
-                return
-
-            if not compile_in_jail(source_code, LOCAL_LANGUAGES_MAP[local_language_id], environment).success:
-                # Compile time error
-                environment.remove_files()
-                await submit_custom_input_judgement(json_data["id"], "COMPILE_TIME_ERROR", b"", b"")
-                return
-
-            language = LOCAL_LANGUAGES_MAP[local_language_id]
-            run_result = run_single(environment, bytes(stdin,"utf-8"), language=language)
-            environment.remove_files()
-
-            await submit_custom_input_judgement(json_data["id"], run_result.result, run_result.stdout, run_result.stderr, run_result.runtime)
+            await handle_custom_input_submission(json_data)
 
 
 

--- a/src/judge/src/app.py
+++ b/src/judge/src/app.py
@@ -39,6 +39,8 @@ NEXTJUDGE_USER_ID = 99999
 TARGET_TOP_LEVEL_DIRECTORY = "program_files"
 GO_CACHE_DIRECTORY = "/var/lib/nextjudge/go-cache"
 GO_MOD_CACHE_DIRECTORY = "/var/lib/nextjudge/go-mod"
+GO_JAIL_CACHE_DIRECTORY = "/home/NEXTJUDGE_USER/go-cache"
+GO_JAIL_MOD_CACHE_DIRECTORY = "/home/NEXTJUDGE_USER/go-mod-cache"
 GO_ROOT_DIRECTORY = "/home/NEXTJUDGE_USER/go"
 
 BUILD_DIRECTORY_NAME = "build"
@@ -629,16 +631,17 @@ def compile_in_jail(source_code: str, language: Language | None, environment: Pr
     ]
 
     if is_go:
+        init_go_cache_directories()
         # use persistent cache directories (initialized at startup)
         nsjail_args.extend([
-            "--bindmount", f"{GO_CACHE_DIRECTORY}:/go_cache",
-            "--bindmount", f"{GO_MOD_CACHE_DIRECTORY}:/go_mod_cache",
+            "--bindmount", f"{GO_CACHE_DIRECTORY}:{GO_JAIL_CACHE_DIRECTORY}",
+            "--bindmount", f"{GO_MOD_CACHE_DIRECTORY}:{GO_JAIL_MOD_CACHE_DIRECTORY}",
         ])
         if os.path.exists(GO_ROOT_DIRECTORY):
             nsjail_args.extend(["--bindmount_ro", f"{GO_ROOT_DIRECTORY}:{GO_ROOT_DIRECTORY}"])
         nsjail_args.extend([
-            "--env", "GOCACHE=/go_cache",
-            "--env", "GOMODCACHE=/go_mod_cache",
+            "--env", f"GOCACHE={GO_JAIL_CACHE_DIRECTORY}",
+            "--env", f"GOMODCACHE={GO_JAIL_MOD_CACHE_DIRECTORY}",
             "--env", "GOROOT=/home/NEXTJUDGE_USER/go",
             "--env", "CGO_ENABLED=0",
             "--env", "GOTOOLCHAIN=local",

--- a/src/judge/tests/test_all.py
+++ b/src/judge/tests/test_all.py
@@ -5,6 +5,7 @@ from pathlib import Path
 @pytest.fixture
 def setup():
     parse_languages()
+    init_go_cache_directories()
     yield
 
 @pytest.mark.parametrize("input_file_name", os.listdir(os.path.join(os.path.dirname(__file__), "test_hello_world")))

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -65,6 +65,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^0.2.1",
         "date-fns": "^3.6.0",
+        "diff": "^9.0.0",
         "embla-carousel-react": "^8.0.4",
         "framer-motion": "^11.18.2",
         "geist": "^1.2.2",
@@ -267,7 +268,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1445,7 +1445,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-3.1.0.tgz",
       "integrity": "sha512-xU/lwKdOyfXtQGqn3VnJjlDrmKXEvMi1mgYxVmukEUtVycIz1nh7oQ40bKTd4cA7rLStqu0740pnhGYxGoqsCg==",
-      "peer": true,
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "source-map": "^0.7.0"
@@ -1502,7 +1501,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
       "integrity": "sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -1822,7 +1820,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1842,7 +1839,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1862,7 +1858,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1882,7 +1877,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -1902,7 +1896,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1922,7 +1915,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1942,7 +1934,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1962,7 +1953,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1982,7 +1972,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2002,7 +1991,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2022,7 +2010,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2042,7 +2029,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3621,7 +3607,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.2.0.tgz",
       "integrity": "sha512-9GCWmVmKUAoRfloboCd+RKm6X17xn7eGL7HnpAZUnjBXBilWCxsKnLMTC/ixSHDKS/A/057M1Tx6ZUXd89sVBw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
@@ -3631,7 +3616,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.0.tgz",
       "integrity": "sha512-8i+v6cMxr2emz4ihCrRiYJPp2/sdYsNNsBzXStlcA+/B9Umpm5Jj3WJKYpgTPM+aeyiqlG/MMI1AucnBm4f1oQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3644,7 +3628,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.0.tgz",
       "integrity": "sha512-eIrPW9PIFgDopQU0e/OPpwCW2QWQDtNZDSsiN4sJO8KdMnWWnXJicnRfzrit5rHwFo+Y98i+w/Y5ScnBAFr1dQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prismjs": "^1.30.0"
       },
@@ -3660,7 +3643,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.5.tgz",
       "integrity": "sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3736,7 +3718,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.15.tgz",
       "integrity": "sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3770,7 +3751,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.15.tgz",
       "integrity": "sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3783,7 +3763,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.11.tgz",
       "integrity": "sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3808,7 +3787,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.11.tgz",
       "integrity": "sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3821,7 +3799,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.12.tgz",
       "integrity": "sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3861,7 +3838,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.13.tgz",
       "integrity": "sha512-F7j9FJ0JN/A4d7yr+aw28p4uX7VLWs7hTHtLo7WRyw4G+Lit6Zucq4UWKRxJC8lpsUdzVmG7aBJnKOT+urqs/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3979,7 +3955,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.5.tgz",
       "integrity": "sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4240,7 +4215,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.9.1.tgz",
       "integrity": "sha512-tifnLL/ARzQ6/FGEJjVwj9UT3v+pENdWHdk9x6F3X0mB1y0SeCjV21wpFLYESzwNdBPAj8NMp8Behv7dBnhIfw==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4518,7 +4492,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.9.1.tgz",
       "integrity": "sha512-mvV86fr7kEuDYEApQ2uMPCKL2uagUE0BsXiyyz3KOkY1zifyVm1fzdkscb24Qy1GmLzWAIIihA+3UHNRgYdOlQ==",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.2.1",
         "prosemirror-collab": "^1.3.1",
@@ -4995,7 +4968,6 @@
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5006,7 +4978,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -5288,7 +5259,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5784,7 +5754,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -5953,7 +5922,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -6564,7 +6532,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6974,7 +6941,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7130,7 +7096,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -7312,9 +7277,10 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -7523,8 +7489,7 @@
     "node_modules/embla-carousel": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.3.0.tgz",
-      "integrity": "sha512-Ve8dhI4w28qBqR8J+aMtv7rLK89r1ZA5HocwFz6uMB/i5EiC7bGI7y+AM80yAVUJw3qqaZYK7clmZMUR8kM3UA==",
-      "peer": true
+      "integrity": "sha512-Ve8dhI4w28qBqR8J+aMtv7rLK89r1ZA5HocwFz6uMB/i5EiC7bGI7y+AM80yAVUJw3qqaZYK7clmZMUR8kM3UA=="
     },
     "node_modules/embla-carousel-react": {
       "version": "8.3.0",
@@ -7887,7 +7852,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8050,7 +8014,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -10171,7 +10134,6 @@
         "https://github.com/sponsors/katex"
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "^8.3.0"
       },
@@ -10907,7 +10869,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -11947,7 +11908,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
       "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -13743,7 +13703,6 @@
       "version": "8.13.1",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.1.tgz",
       "integrity": "sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.7.0",
         "pg-pool": "^3.7.0",
@@ -13967,7 +13926,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -14155,7 +14113,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -14345,7 +14302,6 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.23.0.tgz",
       "integrity": "sha512-Q/fgsgl/dlOAW9ILu4OOhYWQbc7TQd4BwKH/RwmUjyVf8682Be4zj3rOYdLnYEcGzyg8LL9Q5IWYKD8tdToreQ==",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -14372,7 +14328,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -14417,7 +14372,6 @@
       "version": "1.34.3",
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.34.3.tgz",
       "integrity": "sha512-mKZ54PrX19sSaQye+sef+YjBbNu2voNwLS1ivb6aD2IRmxRGW64HU9B644+7OfJStGLyxvOreKqEgfvXa91WIA==",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -14474,7 +14428,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14511,7 +14464,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14702,7 +14654,6 @@
       "version": "7.53.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
       "integrity": "sha512-6aiQeBda4zjcuaugWvim9WsGqisoUk+etmFEsSUMm451/Ic8L/UAb7sRtMj3V+Hdzm6mMjU1VhiSzYUZeBm0Vg==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14717,8 +14668,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-latex": {
       "version": "2.0.0",
@@ -14818,7 +14768,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15104,8 +15053,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15647,7 +15595,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.80.4.tgz",
       "integrity": "sha512-rhMQ2tSF5CsuuspvC94nPM9rToiAFw2h3JTrLlgmNw1MH79v8Cr3DH6KF6o6r+8oofY3iYVPUf66KzC8yuVN1w==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
@@ -16467,7 +16414,6 @@
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.14.tgz",
       "integrity": "sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -16776,8 +16722,7 @@
     "node_modules/tslib": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
-      "peer": true
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -16881,7 +16826,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16937,7 +16881,6 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -17183,6 +17126,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/uvu/node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/vary": {
@@ -17640,7 +17592,6 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -66,6 +66,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^0.2.1",
     "date-fns": "^3.6.0",
+    "diff": "^9.0.0",
     "embla-carousel-react": "^8.0.4",
     "framer-motion": "^11.18.2",
     "geist": "^1.2.2",

--- a/src/web/src/app/globals.css
+++ b/src/web/src/app/globals.css
@@ -52,6 +52,32 @@
 		--success-foreground: 144.9 80.4% 10%;
 		--ring: 23.11 59.8% 40%;
 	}
+
+	.editor-workspace {
+		-webkit-user-select: none;
+		user-select: none;
+		--success-green: #28c244;
+		--color-section-splitter: #1a90ff;
+		--background: 0 0% 3.9%;
+		--foreground: 0 0% 98%;
+		--card: 0 0% 3.9%;
+		--card-foreground: 0 0% 98%;
+		--popover: 0 0% 3.9%;
+		--popover-foreground: 0 0% 98%;
+		--primary: 0 0% 98%;
+		--primary-foreground: 0 0% 9%;
+		--secondary: 0 0% 14.9%;
+		--secondary-foreground: 0 0% 98%;
+		--muted: 0 0% 14.9%;
+		--muted-foreground: 0 0% 63.9%;
+		--accent: 0 0% 14.9%;
+		--accent-foreground: 0 0% 98%;
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 0 0% 98%;
+		--border: 0 0% 14.9%;
+		--input: 0 0% 14.9%;
+		--ring: 0 0% 83.1%;
+	}
 }
 
 @layer base {
@@ -123,4 +149,24 @@
 
 .ProseMirror:focus {
 	outline: none;
+}
+
+.editor-workspace :is(.monaco-editor, textarea, input, [contenteditable="true"], .select-all),
+.editor-workspace :is(.monaco-editor, textarea, input, [contenteditable="true"], .select-all) * {
+	-webkit-user-select: text;
+	user-select: text;
+}
+
+.editor-workspace code {
+	background-color: #353535;
+	border: 1px solid gray;
+	border-radius: 4px;
+	padding: 2px;
+}
+
+.editor-prose code {
+	background-color: #353535;
+	border: 1px solid gray;
+	border-radius: 4px;
+	padding: 2px;
 }

--- a/src/web/src/app/platform/layout.tsx
+++ b/src/web/src/app/platform/layout.tsx
@@ -22,7 +22,7 @@ export default function PlatformLayout({ children }: PlatformLayoutProps) {
 
   return (
     <SessionProvider>
-      <main className="flex flex-col items-center justify-center overflow-x-hidden">
+      <main className={isEditorPage ? "h-screen overflow-hidden" : "flex flex-col items-center justify-center overflow-x-hidden"}>
         {children}
       </main>
       {!isEditorPage && <Footer />}

--- a/src/web/src/app/platform/problems/(problem)/[id]/page.tsx
+++ b/src/web/src/app/platform/problems/(problem)/[id]/page.tsx
@@ -69,21 +69,28 @@ export default async function Editor({
     const languages = languagesResult.status === 'fulfilled' ? languagesResult.value : []
 
     return (
-        <>
+        <div className="editor-workspace dark h-screen flex flex-col overflow-hidden bg-background text-foreground">
             <EditorThemeProvider>
-                <EditorNavbar notificationSlot={<NotificationBellServer session={session} />}>
-                    <UserAvatar session={session} />
-                </EditorNavbar>
-                <EditorComponent
-                    details={details}
-                    testCases={testCases}
-                    recentSubmissions={recentSubmissions}
-                    languages={languages}
-                    tags={tags}
-                    contestId={contestId}
-                    slot={<MarkdownRenderer prompt={details.prompt} />}
-                />
+                    <main className="px-2 pb-2 flex flex-col flex-1 min-h-0">
+                        <EditorNavbar
+                            notificationSlot={<NotificationBellServer session={session} />}
+                            backHref={contestId ? `/platform/contests/${contestId}` : "/platform/problems"}
+                        >
+                            <UserAvatar session={session} />
+                        </EditorNavbar>
+                        <div className="flex-1 min-h-0">
+                            <EditorComponent
+                                details={details}
+                                testCases={testCases}
+                                recentSubmissions={recentSubmissions}
+                                languages={languages}
+                                tags={tags}
+                                contestId={contestId}
+                                slot={<MarkdownRenderer prompt={details.prompt} />}
+                            />
+                        </div>
+                    </main>
             </EditorThemeProvider>
-        </>
+        </div>
     );
 }

--- a/src/web/src/components/editor/code-editor.tsx
+++ b/src/web/src/components/editor/code-editor.tsx
@@ -7,13 +7,21 @@ import type { Language } from "@/lib/types";
 import { convertToMonacoLanguageName } from "@/lib/utils";
 import { ThemeContext } from "@/providers/editor-theme";
 import type { Theme } from "@/types";
-import Editor, { type Monaco } from "@monaco-editor/react";
+import Editor, { type Monaco, useMonaco } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { Check, Play, RotateCcw } from "lucide-react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useClickAway } from "react-use";
 import { toast } from "sonner";
 import { Icons } from "../icons";
 import { Button } from "../ui/button";
+import { Separator } from "../ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../ui/tooltip";
 import { EditorLanguageSelect } from "./editor-language-select";
 import { EditorThemeSelector } from "./editor-theme-select";
 
@@ -63,6 +71,7 @@ fun main(args: Array<String>) {
     pypy: ``,
 };
 
+const CHEETCODE_EDITOR_THEME = "nextjudge-cheetcode";
 
 function getLanguageTemplateCode(language: Language): string {
     if (templates[language.name]) {
@@ -81,27 +90,25 @@ export default function CodeEditor({
     code,
     setCode,
     submissionLoading,
-    error,
     handleSubmitCode,
-    customInputLoading,
-    handleRunCustomInput,
+    runLoading,
+    onRun,
 }: {
     languages: Language[],
-        themes: Theme[];
-        problemId: number;
+    themes: Theme[];
+    problemId: number;
     code: string;
     setCode: (code: string) => void;
     submissionLoading: boolean;
-        error: string | null;
     handleSubmitCode: (languageId: string, problemId: number) => Promise<void>;
-        customInputLoading: boolean;
-        handleRunCustomInput: (languageId: string) => Promise<void>;
+    runLoading: boolean;
+    onRun: (languageId: string) => Promise<void>;
 }) {
     const { theme } = useContext(ThemeContext);
+    const monaco = useMonaco();
     const { defaultLanguage } = useSettingsStore();
     const isLanguagesUnavailable = languages.length === 1 && languages[0].id === FALLBACK_TYPESCRIPT.id;
     const [currentLanguage, setCurrentLanguage] = useState<Language>(() => {
-        // Use default language from settings if available, otherwise fall back to languages[3]
         if (defaultLanguage && languages.some(lang => lang.id === defaultLanguage.id)) {
             return defaultLanguage;
         }
@@ -111,7 +118,6 @@ export default function CodeEditor({
     const hasLoadedInitialTemplate = useRef(false);
     const previousLanguageRef = useRef<Language | null>(null);
 
-    // Load template code on initial mount if we have a default language and the editor is empty
     useEffect(() => {
         if (currentLanguage && !hasLoadedInitialTemplate.current && code.trim() === "") {
             const templateCode = getLanguageTemplateCode(currentLanguage);
@@ -123,7 +129,6 @@ export default function CodeEditor({
         }
     }, []);
 
-    // Load template when language changes (user switches language)
     useEffect(() => {
         if (currentLanguage && hasLoadedInitialTemplate.current && previousLanguageRef.current?.id !== currentLanguage.id) {
             const templateCode = getLanguageTemplateCode(currentLanguage);
@@ -133,31 +138,14 @@ export default function CodeEditor({
             previousLanguageRef.current = currentLanguage;
         }
     }, [currentLanguage, setCode]);
-    const [screenWidth, setScreenWidth] = useState<number>(typeof window !== 'undefined' ? window.innerWidth : 1200);
 
-    useEffect(() => {
-        const handleResize = () => {
-            setScreenWidth(window.innerWidth);
-            if (editorRef.current) {
-                setTimeout(() => {
-                    editorRef.current?.layout();
-                }, 100);
-            }
-        };
-        window.addEventListener('resize', handleResize);
-        return () => window.removeEventListener('resize', handleResize);
-    }, []);
+    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+    const editorContainerRef = useRef<HTMLDivElement | null>(null);
 
-    useEffect(() => {
-        if (editorRef.current) {
-            const timer = setTimeout(() => {
-                editorRef.current?.layout();
-            }, 50);
-            return () => clearTimeout(timer);
-        }
-    }, []);
+    useClickAway(editorContainerRef, () => {
+        // retained for potential future focus styling
+    });
 
-    // Update current language when default language changes
     useEffect(() => {
         if (defaultLanguage && languages.some(lang => lang.id === defaultLanguage.id)) {
             setCurrentLanguage(defaultLanguage);
@@ -168,9 +156,7 @@ export default function CodeEditor({
         if (editorRef.current) {
             const container = editorRef.current.getContainerDomNode();
             const resizeObserver = new ResizeObserver(() => {
-                if (editorRef.current) {
-                    editorRef.current.layout();
-                }
+                editorRef.current?.layout();
             });
 
             resizeObserver.observe(container);
@@ -181,20 +167,62 @@ export default function CodeEditor({
         }
     }, []);
 
-    // Need to wait to do this - it updates parent component otherwise causing a crash
-    // setCode(templates[normalizeLanguageKey(languages[0].name)]);
+    useEffect(() => {
+        if (!monaco || !theme?.name) {
+            return;
+        }
 
-    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
-    const editorContainerRef = useRef<HTMLDivElement | null>(null);
-    const [isEditorFocused, setIsEditorFocused] = useState(false);
+        const applyEditorTheme = async () => {
+            const isLightTheme = theme.name === "light" || theme.name.includes("light");
+            const editorBackground = isLightTheme ? "#ffffff" : "#0a0a0a";
+            const patchedThemeName = `${theme.name}-workspace`;
 
-    useClickAway(editorContainerRef, () => {
-        setIsEditorFocused(false);
-    });
+            if (theme.fetch) {
+                try {
+                    const response = await fetch(theme.fetch);
+                    const themeData = await response.json();
+                    monaco.editor.defineTheme(patchedThemeName, {
+                        ...themeData,
+                        colors: {
+                            ...themeData.colors,
+                            "editor.background": editorBackground,
+                        },
+                    });
+                    monaco.editor.setTheme(patchedThemeName);
+                    return;
+                } catch {
+                    // Fall through to built-in theme patch below.
+                }
+            }
+
+            monaco.editor.defineTheme(patchedThemeName, {
+                base: isLightTheme ? "vs" : "vs-dark",
+                inherit: true,
+                rules: [],
+                colors: {
+                    "editor.background": editorBackground,
+                },
+            });
+            monaco.editor.setTheme(patchedThemeName);
+        };
+
+        void applyEditorTheme();
+    }, [monaco, theme]);
+
+    const handleSubmit = useCallback(async () => {
+        await handleSubmitCode(currentLanguage?.id as string, problemId);
+    }, [currentLanguage?.id, handleSubmitCode, problemId]);
+
+    const handleRun = useCallback(async () => {
+        await onRun(currentLanguage?.id as string);
+    }, [currentLanguage?.id, onRun]);
+
+    const actionsDisabled =
+        isLanguagesUnavailable || runLoading || submissionLoading;
 
     const handleEditorDidMount = (
         editor: editor.IStandaloneCodeEditor,
-        monaco: Monaco
+        monacoInstance: Monaco
     ) => {
         editorRef.current = editor;
         editor.focus();
@@ -203,20 +231,20 @@ export default function CodeEditor({
             editor.layout();
         }, 0);
 
-        monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-            module: monaco.languages.typescript.ModuleKind.CommonJS,
+        monacoInstance.languages.typescript.typescriptDefaults.setCompilerOptions({
+            module: monacoInstance.languages.typescript.ModuleKind.CommonJS,
             allowJs: true,
             checkJs: true,
         });
 
-        monaco.languages.typescript.javascriptDefaults.setEagerModelSync(true);
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(
+        monacoInstance.languages.typescript.javascriptDefaults.setEagerModelSync(true);
+        monacoInstance.languages.typescript.typescriptDefaults.addExtraLib(
             `declare var process: NodeJS.Process;`
         );
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(
+        monacoInstance.languages.typescript.typescriptDefaults.addExtraLib(
             "node:readline/promises"
         );
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(
+        monacoInstance.languages.typescript.typescriptDefaults.addExtraLib(
             "node_modules/@types/node/index.d.ts"
         );
 
@@ -224,14 +252,6 @@ export default function CodeEditor({
         if (editorElement && editorContainerRef.current) {
             editorContainerRef.current = editorElement as HTMLDivElement;
         }
-
-        editor.onDidFocusEditorWidget(() => {
-            setIsEditorFocused(true);
-        });
-
-        editor.onDidBlurEditorWidget(() => {
-            setIsEditorFocused(false);
-        });
 
         if (editorElement) {
             const handleKeyDown = (e: KeyboardEvent) => {
@@ -261,144 +281,133 @@ export default function CodeEditor({
         }
     };
 
-
     const handleLanguageSelect = (language: Language) => {
-        // Always load template code when switching languages
         setCode(getLanguageTemplateCode(language));
         setCurrentLanguage(language);
+    };
+
+    const handleClearEditor = () => {
+        setCode("");
+        toast.success("Editor cleared successfully!");
     };
 
     const editorOptions = useMemo(
         () => ({
             ...defaultEditorOptions,
             automaticLayout: true,
+            minimap: { enabled: false },
+            quickSuggestions: false,
             scrollBeyondLastLine: false,
-            wordWrap: 'on' as const,
-            wrappingStrategy: 'advanced' as const,
-            fontSize: screenWidth < 640 ? 12 : screenWidth < 1024 ? 13 : 14,
-            lineHeight: screenWidth < 640 ? 18 : screenWidth < 1024 ? 19 : 20,
+            contextmenu: false,
+            wordWrap: "on" as const,
+            fontSize: 14,
+            lineHeight: 20,
             fontFamily: 'JetBrains Mono, Consolas, "Courier New", monospace',
-            minimap: {
-                enabled: screenWidth > 1024 // Only show minimap on larger screens
-            },
-            lineNumbers: screenWidth < 640 ? 'off' as const : 'on' as const,
-            glyphMargin: screenWidth > 768,
-            folding: screenWidth > 768,
-            lineDecorationsWidth: screenWidth < 640 ? 0 : 10,
-            lineNumbersMinChars: screenWidth < 640 ? 0 : 3,
-            renderLineHighlight: screenWidth < 640 ? 'none' as const : 'line' as const,
+            lineNumbers: "on" as const,
+            glyphMargin: false,
+            folding: true,
             guides: {
                 indentation: false,
             },
-            autoIndent: "full" as const,
-            // Ensure editor takes full width and height
             fixedOverflowWidgets: true,
             overviewRulerBorder: false,
             scrollbar: {
-                vertical: 'auto' as const,
-                horizontal: 'auto' as const,
-                verticalScrollbarSize: 14,
-                horizontalScrollbarSize: 14,
+                vertical: "auto" as const,
+                horizontal: "auto" as const,
+                verticalScrollbarSize: 10,
+                horizontalScrollbarSize: 10,
             },
         }),
-        [screenWidth]
+        []
     );
 
-    const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
-        e.preventDefault();
-        await handleSubmitCode(currentLanguage?.id as string, problemId);
-    };
-
-    const handleRun = async (e: React.MouseEvent<HTMLButtonElement>) => {
-        e.preventDefault();
-        await handleRunCustomInput(currentLanguage?.id as string);
-    };
+    const monacoTheme = theme?.name ? `${theme.name}-workspace` : CHEETCODE_EDITOR_THEME;
 
     return (
-        <div className="h-full w-full overflow-hidden flex flex-col bg-card">
-            <div className="flex justify-between items-center flex-wrap gap-3 p-3 sm:p-4 border-b border-border bg-muted/30">
-                <div className="flex items-center gap-3 min-w-0">
-                    <EditorLanguageSelect
-                        languages={languages}
-                        onLanguageSelect={handleLanguageSelect}
-                        defaultLanguage={currentLanguage}
-                    />
-                </div>
-                <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-                    <Button
-                        variant="outline"
-                        size="icon"
-                        className="h-8 w-8 sm:h-9 sm:w-9"
-                        onClick={handleRun}
-                        disabled={customInputLoading || submissionLoading || isLanguagesUnavailable}
-                        title="Run with custom input"
-                        aria-label="Run with custom input"
-                    >
-                        {customInputLoading ? (
-                            <Icons.loader className="w-4 h-4 animate-spin" />
-                        ) : (
-                            <Icons.play className="w-4 h-4" />
-                        )}
-                    </Button>
-                    <Button
-                        className="text-xs sm:text-sm px-3 sm:px-4 py-2 font-medium"
-                        onClick={handleSubmit}
-                        disabled={submissionLoading || customInputLoading || isLanguagesUnavailable}
-                        variant={error ? "destructive" : "default"}
-                        size="sm"
-                    >
-                        {submissionLoading ? (
-                            <div className="flex items-center justify-center gap-2">
-                                <Icons.loader className="w-4 h-4 animate-spin" />
-                                <span className="hidden sm:inline">Submitting...</span>
+        <Tabs defaultValue="code" className="h-full flex flex-col">
+            <TabsList className="flex justify-start w-full h-9 shrink-0 rounded-none bg-muted/40 p-1">
+                <TabsTrigger value="code" className="px-2 py-1 h-7">
+                    Code
+                </TabsTrigger>
+            </TabsList>
+            <TabsContent value="code" className="flex-1 min-h-0 mt-0 data-[state=inactive]:hidden">
+                <div className="flex flex-col h-full">
+                    <div className="flex items-center justify-between gap-2 h-8 px-2 py-1 shrink-0">
+                        <EditorLanguageSelect
+                            languages={languages}
+                            onLanguageSelect={handleLanguageSelect}
+                            defaultLanguage={currentLanguage}
+                            variant="compact"
+                        />
+                        <div className="flex items-center gap-1.5">
+                            <div className="flex items-center">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-7 gap-1.5 rounded-r-none border-r-0 px-2.5 shadow-none"
+                                    onClick={() => void handleRun()}
+                                    disabled={actionsDisabled}
+                                >
+                                    {runLoading ? (
+                                        <Icons.loader className="h-3.5 w-3.5 animate-spin" />
+                                    ) : (
+                                        <Play className="h-3.5 w-3.5" />
+                                    )}
+                                    Run
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    className="h-7 gap-1.5 rounded-l-none px-2.5 bg-[var(--success-green)] text-white hover:bg-[var(--success-green)]/90 shadow-none"
+                                    onClick={() => void handleSubmit()}
+                                    disabled={actionsDisabled}
+                                >
+                                    {submissionLoading ? (
+                                        <Icons.loader className="h-3.5 w-3.5 animate-spin" />
+                                    ) : (
+                                        <Check className="h-3.5 w-3.5" />
+                                    )}
+                                    Submit
+                                </Button>
                             </div>
-                        ) : (
-                            <>
-                                {error ? (
-                                    <div className="text-xs sm:text-sm text-center truncate max-w-[120px] sm:max-w-none">{error}</div>
-                                ) : (
-                                    <>
-                                        <span className="hidden sm:inline">Submit Code</span>
-                                        <span className="sm:hidden">Submit</span>
-                                    </>
-                                )}
-                            </>
-                        )}
-                    </Button>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        className="text-xs sm:text-sm px-3 sm:px-4 py-2"
-                        onClick={() => {
-                            setCode("");
-                            toast.success("Editor cleared successfully!");
-                        }}
-                    >
-                        <span className="hidden sm:inline">Clear Editor</span>
-                        <span className="sm:hidden">Clear</span>
-                    </Button>
-                </div>
-                <div className="flex items-center min-w-0">
-                    <EditorThemeSelector themes={themes} />
-                </div>
-            </div>
-
-            <div ref={editorContainerRef} className="flex-1 min-h-0">
-                <Editor
-                    loading={
-                        <div className="flex items-center justify-center h-full bg-background">
-                            <Icons.loader className="w-8 h-8 animate-spin text-primary" />
+                            <Separator orientation="vertical" className="h-4" />
+                            <EditorThemeSelector themes={themes} variant="compact" />
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        variant="ghost"
+                                        className="h-6 p-1"
+                                        onClick={handleClearEditor}
+                                        aria-label="Clear editor"
+                                    >
+                                        <RotateCcw className="!w-3.5 !h-3.5" />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>Clear editor</p>
+                                </TooltipContent>
+                            </Tooltip>
                         </div>
-                    }
-                    language={convertToMonacoLanguageName(currentLanguage)}
-                    defaultLanguage={currentLanguage?.name}
-                    value={code}
-                    theme={theme?.name}
-                    options={editorOptions}
-                    onChange={(value) => setCode(value ?? "")}
-                    onMount={handleEditorDidMount}
-                />
-            </div>
-        </div>
+                    </div>
+                    <Separator />
+                    <div ref={editorContainerRef} className="flex-1 min-h-0">
+                        <Editor
+                            height="100%"
+                            loading={
+                                <div className="flex items-center justify-center h-full bg-[#0a0a0a]">
+                                    <Icons.loader className="w-8 h-8 animate-spin text-primary" />
+                                </div>
+                            }
+                            language={convertToMonacoLanguageName(currentLanguage)}
+                            defaultLanguage={currentLanguage?.name}
+                            value={code}
+                            theme={monacoTheme}
+                            options={editorOptions}
+                            onChange={(value) => setCode(value ?? "")}
+                            onMount={handleEditorDidMount}
+                        />
+                    </div>
+                </div>
+            </TabsContent>
+        </Tabs>
     );
 }

--- a/src/web/src/components/editor/editor-language-select.tsx
+++ b/src/web/src/components/editor/editor-language-select.tsx
@@ -23,7 +23,7 @@ interface EditorLanguageSelectProps {
   languages: Language[],
   onLanguageSelect: (language: Language) => void;
   defaultLanguage?: Language;
-  variant?: "default" | "landing";
+  variant?: "default" | "landing" | "compact";
 }
 
 export function EditorLanguageSelect({
@@ -42,27 +42,35 @@ export function EditorLanguageSelect({
   }
 
   const isLanding = variant === "landing";
+  const isCompact = variant === "compact";
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
-          variant="outline"
+          variant={isCompact ? "ghost" : "outline"}
           role="combobox"
           aria-expanded={open}
           className={cn(
-            "w-[200px] justify-between",
+            isCompact
+              ? "h-6 w-fit px-2 text-sm font-normal hover:bg-accent"
+              : "w-[200px] justify-between",
             isLanding && "bg-black/60 border-osu/50 text-white hover:bg-black/80 hover:text-white"
           )}
         >
           {currentLanguage
-            ? `${currentLanguage.name} (${currentLanguage.version})`
+            ? isCompact
+              ? currentLanguage.name.charAt(0).toUpperCase() + currentLanguage.name.slice(1)
+              : `${currentLanguage.name} (${currentLanguage.version})`
             : "Select a language"}
-          <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          <CaretSortIcon className={cn(
+            "shrink-0 opacity-50",
+            isCompact ? "ml-1 h-3.5 w-3.5" : "ml-2 h-4 w-4"
+          )} />
         </Button>
       </PopoverTrigger>
       <PopoverContent className={cn(
-        "w-[200px] p-0",
+        isCompact ? "w-[220px] p-0" : "w-[200px] p-0",
         isLanding && "bg-black/90 border-osu/50"
       )}>
         <Command className={isLanding ? "bg-black/90" : ""}>

--- a/src/web/src/components/editor/editor-layout.tsx
+++ b/src/web/src/components/editor/editor-layout.tsx
@@ -2,49 +2,64 @@
 
 import "@/app/globals.css";
 
-import { RecentSubmissionCard } from "@/app/platform/problems/components/recent-submissions";
 import { EditorSkeleton } from "@/components/editor/editor-skeleton";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer";
+import { ProblemSection } from "@/components/editor/problem-section";
+import { TestcaseSection } from "@/components/editor/testcase-section";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useEditorCollapse } from "@/hooks/useEditorCollapse";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { useThemesLoader } from "@/hooks/useThemeLoader";
-import { apiGetSubmissionsStatus, getCustomInputSubmissionStatus, postCustomInputSubmission, postSolution } from "@/lib/api";
-import { CustomInputResult as CustomInputResultType, Language, Problem, Submission, statusMap, TestCase } from "@/lib/types";
-import { cn } from "@/lib/utils";
-import "katex/dist/katex.min.css";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
+import {
+  apiGetSubmissionsStatus,
+  getCustomInputSubmissionStatus,
+  postCustomInputSubmission,
+  postSolution,
+} from "@/lib/api";
+import {
+  CustomInputResult as CustomInputResultType,
+  Language,
+  PracticeRunResult,
+  Problem,
+  Submission,
+  SubmissionStatus,
+  statusMap,
+  TestCase,
+} from "@/lib/types";
+import { compareOutput } from "@/lib/utils";
 import { useSession } from "next-auth/react";
-import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Icons } from "../icons";
-import {
-  CustomInput,
-  CustomInputResult,
-  Expected,
-  Input as InputCase,
-  Output,
-} from "../submit-box";
-import { Badge } from "../ui/badge";
-import { Button } from "../ui/button";
-import { TooltipProvider } from "../ui/tooltip";
 import CodeEditor from "./code-editor";
-import { SubmissionState } from "./editor-submission-state";
+
+const EDITOR_SELECTABLE_SELECTOR =
+  ".monaco-editor, textarea, input, [contenteditable='true'], .select-all";
+
+function isEditorSelectableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return Boolean(target.closest(EDITOR_SELECTABLE_SELECTOR));
+}
+
+async function executeCodeWithInput(
+  token: string,
+  code: string,
+  languageId: string,
+  stdin: string
+): Promise<CustomInputResultType> {
+  const runId = await postCustomInputSubmission(token, code, languageId, stdin);
+
+  let result = await getCustomInputSubmissionStatus(token, runId);
+  while (!result.finished && result.status === "PENDING") {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    result = await getCustomInputSubmissionStatus(token, runId);
+  }
+
+  return result;
+}
 
 export default function EditorComponent({
   details,
@@ -63,104 +78,112 @@ export default function EditorComponent({
   languages: Language[];
   contestId?: number;
 }) {
-  const { data: session } = useSession()
-  const [screenWidth, setScreenWidth] = useState<number>(typeof window !== 'undefined' ? window.innerWidth : 1200);
-
-  // separate public and hidden test cases
-  const publicTestCases = testCases.filter(tc => !tc.hidden);
-  const hiddenTestCases = testCases.filter(tc => tc.hidden);
-
-  // Responsive screen width tracking
-  useEffect(() => {
-    const handleResize = () => setScreenWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  const { isCollapsed, ref, collapse, expand } = useEditorCollapse();
-  const {
-    isCollapsed: isCollapsed2,
-    ref: ref2,
-    collapse: collapse2,
-    expand: expand2,
-  } = useEditorCollapse();
-  const { resolvedTheme } = useTheme();
+  const { data: session } = useSession();
   const { themes, loading } = useThemesLoader();
-  // const { onSelect } = useEditorTheme(resolvedTheme, defaultColorScheme);
+
+  const publicTestCases = testCases.filter((tc) => !tc.hidden);
+  const hiddenTestCases = testCases.filter((tc) => tc.hidden);
+
   const [input, setInput] = useState("");
-  const router = useRouter();
-  const [recentSubs, setRecentSubs] = useState(recentSubmissions);
   const [code, setCode] = useState<string>("");
 
-  // Submission button stuff
   const [submissionLoading, setSubmissionLoading] = useState(false);
   const [submissionError, setSubmissionError] = useState<string>("");
-  const [currentSubmissionDetails, setCurrentSubmissionDetails] = useState<Submission | null>(null);
+  const [currentSubmissionDetails, setCurrentSubmissionDetails] =
+    useState<Submission | null>(null);
 
-  // Custom input run state
-  const [customInputResult, setCustomInputResult] = useState<CustomInputResultType | null>(null);
-  const [customInputLoading, setCustomInputLoading] = useState(false);
+  const [runResults, setRunResults] = useState<PracticeRunResult | null>(null);
+  const [runLoading, setRunLoading] = useState(false);
+  const [runningCaseIndex, setRunningCaseIndex] = useState<number | null>(null);
+  const [activeCaseTab, setActiveCaseTab] = useState(
+    publicTestCases.length > 0 ? "case-0" : "case-custom"
+  );
+  const [customInputResult, setCustomInputResult] =
+    useState<CustomInputResultType | null>(null);
 
-  // Responsive panel sizes based on screen width
-  const getResponsivePanelSizes = () => {
-    if (screenWidth < 768) {
-      return { leftPanel: 100, rightPanel: 0 }; // Full width on mobile, hide right panel
-    } else if (screenWidth < 1024) {
-      return { leftPanel: 45, rightPanel: 55 }; // Tablet sizes
-    } else if (screenWidth < 1440) {
-      return { leftPanel: 35, rightPanel: 65 }; // Desktop
-    } else {
-      return { leftPanel: 30, rightPanel: 70 }; // Large screens
+  useEffect(() => {
+    const workspace = document.querySelector(".editor-workspace");
+    if (!workspace) {
+      return;
     }
-  };
 
-  const { leftPanel, rightPanel } = getResponsivePanelSizes();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        (event.ctrlKey || event.metaKey) &&
+        event.key.toLowerCase() === "a" &&
+        !isEditorSelectableTarget(event.target)
+      ) {
+        event.preventDefault();
+      }
+    };
+
+    const handleSelectStart = (event: Event) => {
+      if (!isEditorSelectableTarget(event.target)) {
+        event.preventDefault();
+      }
+    };
+
+    workspace.addEventListener("keydown", handleKeyDown);
+    workspace.addEventListener("selectstart", handleSelectStart);
+
+    return () => {
+      workspace.removeEventListener("keydown", handleKeyDown);
+      workspace.removeEventListener("selectstart", handleSelectStart);
+    };
+  }, []);
 
   const handleSubmitCode = async (languageId: string, problemId: number) => {
     if (!languageId) {
       toast.error("Please select a language.");
-      return
+      return;
     }
 
     setSubmissionLoading(true);
     setSubmissionError("");
+    setRunResults(null);
     try {
       if (!session) {
-        throw "Need to be logged in"
+        throw new Error("Need to be logged in");
       }
-      const data = await postSolution(session.nextjudge_token, code, languageId, problemId, session.nextjudge_id, contestId);
-      await fetchSubmissionDetails(data.id)
-    }
-    catch (error: unknown) {
+      const data = await postSolution(
+        session.nextjudge_token,
+        code,
+        languageId,
+        problemId,
+        session.nextjudge_id,
+        contestId
+      );
+      await fetchSubmissionDetails(data.id);
+    } catch (error: unknown) {
       toast.error("There was an error submitting your code.");
-      setSubmissionError(error instanceof Error ? error.message : "An error occurred.");
+      setSubmissionError(
+        error instanceof Error ? error.message : "An error occurred."
+      );
     } finally {
       setSubmissionLoading(false);
     }
   };
 
-  const fetchSubmissionDetails = (async (submissionId: string) => {
+  const fetchSubmissionDetails = async (submissionId: string) => {
     try {
       if (!session) {
-        throw "Need to be logged in"
+        throw new Error("Need to be logged in");
       }
-      console.log("Submission ID", submissionId)
-      let data: Submission = await apiGetSubmissionsStatus(session.nextjudge_token, submissionId)
+      let data: Submission = await apiGetSubmissionsStatus(
+        session.nextjudge_token,
+        submissionId
+      );
       while (data.status === "PENDING") {
-        console.log("Waiting for submission to complete...");
         await new Promise((resolve) => setTimeout(resolve, 1000));
-        data = await apiGetSubmissionsStatus(session.nextjudge_token, submissionId)
+        data = await apiGetSubmissionsStatus(
+          session.nextjudge_token,
+          submissionId
+        );
       }
-
-      // ref2.current?.expand();
-      // expand2();
-      // const submissions = await apiGetRecentSubmissionsForProblem(details.id);
-      // setRecentSubs(submissions);
 
       setSubmissionLoading(false);
       setCurrentSubmissionDetails(data);
 
-      // Show toast based on final status
       const statusMessage = statusMap[data.status];
       if (data.status === "ACCEPTED") {
         toast.success(`${statusMessage}!`);
@@ -171,123 +194,158 @@ export default function EditorComponent({
       console.error(error);
       toast.error("Failed to fetch submission results.");
     }
-  });
+  };
 
-  const handleRunCustomInput = async (languageId: string) => {
+  const handleRun = async (languageId: string) => {
     if (!languageId) {
       toast.error("Please select a language.");
       return;
     }
 
-    if (!input.trim()) {
-      toast.error("Please enter custom input.");
-      return;
-    }
-
-    setCustomInputLoading(true);
+    setRunLoading(true);
+    setRunResults(null);
     setCustomInputResult(null);
+    setRunningCaseIndex(null);
+    setCurrentSubmissionDetails(null);
 
     try {
       if (!session) {
         throw new Error("Need to be logged in");
       }
 
-      const runId = await postCustomInputSubmission(
-        session.nextjudge_token,
-        code,
-        languageId,
-        input
-      );
-
-      let result = await getCustomInputSubmissionStatus(session.nextjudge_token, runId);
-      while (!result.finished && result.status === "PENDING") {
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        result = await getCustomInputSubmissionStatus(session.nextjudge_token, runId);
+      if (activeCaseTab === "case-custom") {
+        const result = await executeCodeWithInput(
+          session.nextjudge_token,
+          code,
+          languageId,
+          input
+        );
+        setCustomInputResult(result);
+        return;
       }
 
-      setCustomInputResult(result);
+      if (publicTestCases.length === 0) {
+        toast.error("No sample test cases available.");
+        return;
+      }
 
-      if (result.stderr) {
-        toast.error("Execution completed with errors");
-      } else {
-        toast.success("Execution completed");
+      const testCaseResults: PracticeRunResult["test_case_results"] = [];
+      let overallStatus: SubmissionStatus = "ACCEPTED";
+      let compileStderr = "";
+
+      for (let i = 0; i < publicTestCases.length; i++) {
+        const testCase = publicTestCases[i];
+        setRunningCaseIndex(i);
+
+        const result = await executeCodeWithInput(
+          session.nextjudge_token,
+          code,
+          languageId,
+          testCase.input
+        );
+
+        if (result.status === "COMPILE_TIME_ERROR") {
+          overallStatus = "COMPILE_TIME_ERROR";
+          compileStderr = result.stderr;
+          setRunResults({
+            status: overallStatus,
+            test_case_results: testCaseResults,
+            stderr: compileStderr || undefined,
+          });
+          break;
+        }
+
+        const passed =
+          result.status === "ACCEPTED" &&
+          compareOutput(testCase.expected_output, result.stdout ?? "");
+
+        testCaseResults.push({
+          test_case_id: testCase.id,
+          stdout: result.stdout ?? "",
+          stderr: result.stderr ?? "",
+          passed,
+        });
+
+        if (!passed) {
+          overallStatus =
+            result.status === "ACCEPTED" ? "WRONG_ANSWER" : result.status;
+        }
+
+        setRunResults({
+          status: overallStatus,
+          test_case_results: [...testCaseResults],
+        });
       }
     } catch (error) {
       console.error(error);
-      toast.error("Failed to run custom input.");
+      toast.error("Failed to run test cases.");
     } finally {
-      setCustomInputLoading(false);
+      setRunLoading(false);
+      setRunningCaseIndex(null);
     }
   };
 
   return (
-    <TooltipProvider delayDuration={0}>
-      <div className={cn(
-        "relative w-full bg-background",
-        "h-[calc(100vh-3.55rem)] min-h-[600px]",
-        "max-w-full overflow-hidden",
-        "border border-border rounded-lg shadow-sm",
-        screenWidth < 768 ? "flex flex-col" : ""
-      )}>
-        {screenWidth < 768 ? (
-          // Mobile Layout - Stacked vertically
-          <>
-            <div className="flex-1 overflow-auto bg-card border-b border-border">
-              <div className="p-4 space-y-4">
-                <div className="flex items-center gap-3 mb-4">
-                  <Link href="/platform/problems">
-                    <Button variant="ghost" size="sm" className="gap-2">
-                      <Icons.arrowLeft className="w-4 h-4" />
-                      Back to Problems
-                    </Button>
-                  </Link>
+    <TooltipProvider delayDuration={100}>
+      <div className="h-full min-h-0">
+        <ResizablePanelGroup direction="horizontal" className="h-full">
+          <ResizablePanel defaultSize={50} minSize={25}>
+            <ResizablePanelGroup direction="vertical" className="h-full">
+              <ResizablePanel
+                defaultSize={60}
+                minSize={25}
+                className="border rounded-lg overflow-hidden"
+              >
+                <div className="h-full bg-card">
+                  <ProblemSection
+                    details={details}
+                    tags={tags}
+                    slot={slot}
+                    recentSubmissions={recentSubmissions}
+                  />
                 </div>
-                <div className="flex items-start justify-between gap-3 flex-wrap">
-                  <h1 className="text-lg font-bold break-words flex-1 min-w-0 text-foreground">{details.title}</h1>
-                  <Badge variant="secondary" className="text-xs font-medium shrink-0 px-2 py-1">
-                    {details.difficulty
-                      ? details.difficulty.charAt(0) +
-                      details.difficulty.slice(1).toLowerCase()
-                      : ""}
-                  </Badge>
+              </ResizablePanel>
+              <ResizableHandle
+                withHandle
+                className="my-1 bg-background hover:bg-[var(--color-section-splitter)] transition-all"
+              />
+              <ResizablePanel
+                defaultSize={40}
+                minSize={20}
+                className="border rounded-lg overflow-hidden"
+              >
+                <div className="h-full bg-card">
+                  <TestcaseSection
+                    publicTestCases={publicTestCases}
+                    hiddenTestCases={hiddenTestCases}
+                    input={input}
+                    setInput={setInput}
+                    activeCaseTab={activeCaseTab}
+                    onActiveCaseTabChange={setActiveCaseTab}
+                    runLoading={runLoading}
+                    runResults={runResults}
+                    runningCaseIndex={runningCaseIndex}
+                    customInputResult={customInputResult}
+                    submissionLoading={submissionLoading}
+                    submissionError={submissionError}
+                    currentSubmissionDetails={currentSubmissionDetails}
+                  />
                 </div>
-                {tags.length > 0 && (
-                  <div className="flex items-start gap-2 flex-wrap">
-                    <div className="text-xs text-muted-foreground shrink-0 font-medium">
-                      <span>Tags:</span>
-                    </div>
-                    <div className="flex flex-wrap gap-1">
-                      {tags.map((tag) => (
-                        <Badge
-                          key={tag}
-                          variant="outline"
-                          onClick={() =>
-                            router.push(
-                              `/platform/problems?tag=${tag.toLowerCase()}`
-                            )
-                          }
-                          className={cn(
-                            "text-xs font-medium",
-                            "bg-muted hover:bg-muted/80",
-                            "text-muted-foreground hover:text-foreground",
-                            "hover:underline",
-                            "hover:cursor-pointer",
-                            "transition-colors",
-                            "break-all"
-                          )}
-                        >
-                          {tag}
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                <div className="border-t border-border pt-4">
-                  {slot}
-                </div>
-              </div>
-            </div>
-            <div className="flex-1 min-h-0 bg-card">
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          </ResizablePanel>
+
+          <ResizableHandle
+            withHandle
+            className="mx-1 bg-background hover:bg-[var(--color-section-splitter)] transition-all"
+          />
+
+          <ResizablePanel
+            defaultSize={50}
+            minSize={25}
+            className="border rounded-lg overflow-hidden"
+          >
+            <div className="h-full bg-card">
               {loading && <EditorSkeleton />}
               {!loading && (
                 <CodeEditor
@@ -296,503 +354,15 @@ export default function EditorComponent({
                   problemId={details.id}
                   code={code}
                   setCode={setCode}
-                  error={submissionError}
                   submissionLoading={submissionLoading}
                   handleSubmitCode={handleSubmitCode}
-                  customInputLoading={customInputLoading}
-                  handleRunCustomInput={handleRunCustomInput}
+                  runLoading={runLoading}
+                  onRun={handleRun}
                 />
               )}
             </div>
-          </>
-        ) : (
-          // Desktop Layout - Resizable panels
-          <ResizablePanelGroup
-            direction="horizontal"
-            className="w-full h-full"
-          >
-            {/* Problem Statement Section */}
-            <ResizablePanel
-              defaultSize={leftPanel}
-                className="min-w-0 bg-card overflow-auto"
-              ref={ref}
-                collapsible
-                minSize={20}
-                maxSize={60}
-              onCollapse={collapse}
-            >
-              <div className="h-full flex flex-col border-r border-border">
-                <div className="p-3 sm:p-4 overflow-auto flex-1">
-                  <div className="flex flex-col w-full">
-                    <div className="flex items-center gap-3 mb-4">
-                      <Link href={contestId ? `/platform/contests/${contestId}` : "/platform/problems"}>
-                        <Button variant="ghost" size="sm" className="gap-2">
-                          <Icons.arrowLeft className="w-4 h-4" />
-                          Back to Problems
-                        </Button>
-                      </Link>
-                    </div>
-                    <div className="flex items-start justify-between gap-3 flex-wrap">
-                      <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold break-words flex-1 min-w-0 text-foreground">{details.title}</h1>
-                      <Badge variant="secondary" className="text-sm font-medium shrink-0 px-3 py-1">
-                        {details.difficulty
-                          ? details.difficulty.charAt(0) +
-                          details.difficulty.slice(1).toLowerCase()
-                          : ""}
-                      </Badge>
-                    </div>
-                    {tags.length > 0 && (
-                      <div className="flex items-start gap-3 flex-wrap">
-                        <div className="text-sm text-muted-foreground shrink-0 font-medium">
-                          <span>Tags:</span>
-                        </div>
-                        <div className="flex flex-wrap gap-2">
-                          {tags.map((tag) => (
-                            <Badge
-                              key={tag}
-                              variant="outline"
-                              onClick={() =>
-                                router.push(
-                                  `/platform/problems?tag=${tag.toLowerCase()}`
-                                )
-                              }
-                              className={cn(
-                                "text-xs font-medium",
-                                "bg-muted hover:bg-muted/80",
-                                "text-muted-foreground hover:text-foreground",
-                                "hover:underline",
-                                "hover:cursor-pointer",
-                                "transition-colors",
-                                "break-all"
-                              )}
-                            >
-                              {tag}
-                            </Badge>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    <div className="mt-4 border-t border-border pt-4">
-                      {slot}
-                    </div>
-                  </div>
-                </div>
-              </div>
-              </ResizablePanel>
-              <ResizableHandle
-                withHandle
-                className={cn(
-                  {
-                    "transform translate-x-2 z-50": isCollapsed,
-                  },
-                  "cursor-col-resize hover:bg-muted/50 transition-colors"
-                )}
-                onClickCapture={() => {
-                  if (isCollapsed) {
-                    expand();
-                  } else {
-                    collapse();
-                  }
-                }}
-              />
-            <ResizablePanel
-              defaultSize={rightPanel}
-                className="min-w-0 bg-background"
-              minSize={40}
-            >
-                <ResizablePanelGroup direction="vertical" className="w-full h-full min-h-0">
-                {/*  Code Editor Section */}
-                <ResizablePanel
-                  defaultSize={75}
-                  minSize={30}
-                  maxSize={90}
-                    className="min-w-0 min-h-0 bg-card border-b border-border overflow-hidden"
-                >
-                    <div className="h-full w-full">
-                    {loading && <EditorSkeleton />}
-                    {!loading && (
-                      <CodeEditor
-                        languages={languages}
-                        themes={themes}
-                        problemId={details.id}
-                        code={code}
-                        setCode={setCode}
-                        error={submissionError}
-                        submissionLoading={submissionLoading}
-                        handleSubmitCode={handleSubmitCode}
-                          customInputLoading={customInputLoading}
-                          handleRunCustomInput={handleRunCustomInput}
-                      />
-                    )}
-                  </div>
-                  </ResizablePanel>
-                  <ResizableHandle
-                    withHandle
-                    className={cn(
-                      {
-                        "transform translate-y-2 z-50": isCollapsed2,
-                      },
-                      "cursor-row-resize hover:bg-muted/50 transition-colors"
-                    )}
-                    onClickCapture={() => {
-                      if (isCollapsed2) {
-                        expand2();
-                      } else {
-                        collapse2();
-                      }
-                    }}
-                  />
-                {/* Submission Section */}
-                <ResizablePanel
-                    defaultSize={25}
-                  minSize={10}
-                  maxSize={70}
-                  collapsible
-                  onCollapse={collapse2}
-                  ref={ref2}
-                  collapsedSize={0}
-                    className="min-w-0 min-h-0 bg-card overflow-auto"
-                >
-                  <div className="p-4 sm:p-5 lg:p-6 space-y-4 h-full overflow-auto border-t border-border">
-                    <div className="flex items-center flex-wrap gap-2">
-                      <div className="text-sm sm:text-base lg:text-lg font-bold flex-1 min-w-0">
-                        {/* TODO: clean this up */}
-                        {submissionLoading && (
-                          <div className="flex items-center gap-2">
-                            <span className="text-lg font-bold text-yellow-500">
-                              Pending
-                            </span>
-                            <Icons.loader className="mr-2 w-6 h-6 animate-spin" />
-                          </div>
-                        )}
-                        {submissionError && (
-                          <div className="text-sm text-center">{submissionError}</div>
-                        )}
-                        {!currentSubmissionDetails &&
-                          !submissionLoading &&
-                          !submissionError && <span>Submission Details</span>}
-                        {currentSubmissionDetails && !submissionLoading && (
-                          <SubmissionState submission={currentSubmissionDetails} />
-                        )}
-                      </div>
-                      <div className="flex min-w-0 items-center space-x-2 sm:space-x-4 shrink-0">
-                        <Drawer>
-                          <DrawerTrigger asChild>
-                            <Button
-                              variant="outline"
-                              className="scale-75 sm:scale-90 flex gap-1 sm:gap-2 text-xs sm:text-sm"
-                            >
-                              <Icons.eye className="w-3 h-3 sm:w-4 sm:h-4" />
-                              <span className="hidden sm:inline">View Submissions</span>
-                              <span className="sm:hidden">Submissions</span>
-                            </Button>
-                          </DrawerTrigger>
-                          <DrawerContent>
-                            <DrawerHeader>
-                              <DrawerTitle>Your Submissions</DrawerTitle>
-                              <DrawerDescription>
-                                See your submissions to both this problem and these
-                                tags.
-                              </DrawerDescription>
-                            </DrawerHeader>
-
-                            <div className="mx-6 flex flex-col gap-4">
-                              <Tabs
-                                defaultValue="problem"
-                                className={cn("w-full max-h-96 overflow-y-scroll")}
-                              >
-                                <TabsList>
-                                  <TabsTrigger value="problem">Problem</TabsTrigger>
-                                  <TabsTrigger value="tag">Tag</TabsTrigger>
-                                </TabsList>
-                                <TabsContent value="problem">
-                                  <ul className="grid grid-flow-row grid-cols-3 gap-4">
-                                    {Array.isArray(recentSubmissions) && recentSubmissions.map((submission) => (
-                                      <RecentSubmissionCard
-                                        submission={submission}
-                                        key={submission.id}
-                                      />
-                                    ))}
-                                  </ul>
-                                </TabsContent>
-                                <TabsContent value="category">
-                                  <ul className="grid grid-flow-row grid-cols-3 gap-4">
-                                    {Array.isArray(recentSubmissions) && recentSubmissions.map((submission) => (
-                                      <RecentSubmissionCard
-                                        submission={submission}
-                                        key={submission.id}
-                                      />
-                                    ))}
-                                  </ul>
-                                </TabsContent>
-                              </Tabs>
-                            </div>
-                            <DrawerFooter className={cn("mt-4 w-full")}>
-                              <DrawerClose>
-                                <Button className="w-full" variant="outline">
-                                  Done
-                                </Button>
-                              </DrawerClose>
-                            </DrawerFooter>
-                          </DrawerContent>
-                        </Drawer>
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap gap-x-2 gap-y-2 sm:gap-y-4">
-                      <Tabs
-                          defaultValue={`case-${Math.max(0, (publicTestCases?.length || 1) - 1)}`}
-                        className={cn("w-full")}
-                      >
-                          <TabsList className="flex-wrap h-auto gap-1 p-1">
-                            <TabsTrigger key="custom" value={"case-custom"} className="text-xs sm:text-sm">
-                              <span className="hidden sm:inline">Custom Test Case</span>
-                              <span className="sm:hidden">Custom</span>
-                            </TabsTrigger>
-                            {publicTestCases.map((testCase, index) => {
-                              // Simple status indicator for tabs
-                              const isFailedTestCase = currentSubmissionDetails?.failed_test_case_id === testCase.id;
-                              const isBeforeFailedCase = currentSubmissionDetails?.failed_test_case_id &&
-                                publicTestCases.findIndex(tc => tc.id === currentSubmissionDetails.failed_test_case_id) > index;
-
-                              let statusIcon = "";
-                              if (currentSubmissionDetails) {
-                                if (currentSubmissionDetails.status === "ACCEPTED") {
-                                  statusIcon = "✓";
-                                } else if (isFailedTestCase) {
-                                  statusIcon = "✗";
-                                } else if (isBeforeFailedCase) {
-                                  statusIcon = "✓";
-                                }
-                              }
-
-                              return (
-                                <TabsTrigger key={index} value={`case-${index}`} className="text-xs sm:text-sm">
-                                  <span className="hidden sm:inline">Test Case {index + 1}</span>
-                                  <span className="sm:hidden">TC {index + 1}</span>
-                                  {statusIcon && <span className="ml-1">{statusIcon}</span>}
-                                </TabsTrigger>
-                              );
-                            })}
-                            {hiddenTestCases.length > 0 && (
-                              <TabsTrigger
-                                value="hidden-tests"
-                                className="text-xs sm:text-sm gap-1.5 text-muted-foreground"
-                              >
-                                <Icons.lock className="w-3 h-3" />
-                                <span className="hidden sm:inline">Hidden ({hiddenTestCases.length})</span>
-                                <span className="sm:hidden">{hiddenTestCases.length}</span>
-                              </TabsTrigger>
-                            )}
-                        </TabsList>
-                          {publicTestCases.map((testCase, index) => {
-                          // Determine test case status based on submission details
-                          const isFailedTestCase = currentSubmissionDetails?.failed_test_case_id === testCase.id;
-                            const failedTestCaseIndex = currentSubmissionDetails?.failed_test_case_id
-                              ? publicTestCases.findIndex(tc => tc.id === currentSubmissionDetails.failed_test_case_id)
-                              : -1;
-                            const isBeforeFailedCase = failedTestCaseIndex !== -1 && failedTestCaseIndex > index;
-
-                            // get per-test-case result if available
-                            const testCaseResult = currentSubmissionDetails?.test_case_results?.find(
-                              (r) => r.test_case_id === testCase.id
-                            );
-
-                            let testStatus: "passed" | "failed" | "not-run" | "unknown" = "unknown";
-                          if (currentSubmissionDetails) {
-                            if (testCaseResult) {
-                              testStatus = testCaseResult.passed ? "passed" : "failed";
-                            } else if (currentSubmissionDetails.status === "ACCEPTED") {
-                              testStatus = "passed";
-                            } else if (isFailedTestCase) {
-                              testStatus = "failed";
-                            } else if (isBeforeFailedCase) {
-                              testStatus = "passed";
-                            } else {
-                              testStatus = "not-run";
-                            }
-                          }
-
-                            // only use per-test-case output, don't fall back to global stdout
-                            const outputToShow = testCaseResult?.stdout ?? null;
-
-                            // show stderr: per-test-case stderr, or global stderr for failed test case or compile errors
-                            const isCompileError = currentSubmissionDetails?.status === "COMPILE_TIME_ERROR";
-                            const stderrToShow = testCaseResult?.stderr ?? (
-                              (isFailedTestCase || isCompileError) ? currentSubmissionDetails?.stderr : null
-                            );
-
-                          return (
-                            <TabsContent key={index} value={`case-${index}`}>
-                              <div className="space-y-4">
-                                <InputCase input={testCase.input} />
-                                <Expected expected={testCase.expected_output} />
-
-                                {/* Show actual output based on test status */}
-                                {currentSubmissionDetails ? (
-                                  <div>
-                                    {isCompileError ? (
-                                      // compile error - show error message prominently
-                                      <div className="space-y-2">
-                                        <div className="flex text-xs font-medium text-red-500 mb-2">
-                                          Compilation Failed
-                                        </div>
-                                        {stderrToShow && (
-                                          <Output output={stderrToShow} />
-                                        )}
-                                      </div>
-                                    ) : (
-                                      <>
-                                          <div className="flex text-xs font-medium mb-2">
-                                            <span className={
-                                              testStatus === "passed" ? "text-green-500" :
-                                                testStatus === "failed" ? "text-red-500" :
-                                                  "text-muted-foreground"
-                                            }>
-                                              Your Output {
-                                                testStatus === "passed" ? "✓ (Passed)" :
-                                                  testStatus === "failed" ? "✗ (Failed)" :
-                                                    "(Not Run)"
-                                              }
-                                            </span>
-                                          </div>
-                                          {outputToShow ? (
-                                            <Output output={outputToShow} />
-                                          ) : (
-                                            <div className="text-sm text-muted-foreground p-2 border rounded">
-                                              {testStatus === "not-run"
-                                                ? "Test case not executed"
-                                                : "No per-test-case output available"}
-                                            </div>
-                                          )}
-
-                                          {/* Error output for runtime errors */}
-                                          {stderrToShow && (
-                                            <div className="mt-2">
-                                              <div className="flex text-xs font-medium text-red-500 mb-2">
-                                                Error Output
-                                              </div>
-                                              <Output output={stderrToShow} />
-                                            </div>
-                                          )}
-                                        </>
-                                    )}
-                                  </div>
-                                ) : (
-                                    <div className="space-y-2">
-                                      <label className="text-sm font-medium text-muted-foreground block">
-                                        Output
-                                      </label>
-                                      <div className="text-sm text-muted-foreground p-3 border rounded bg-muted/30">
-                                        Submit your solution to see output
-                                      </div>
-                                    </div>
-                                )}
-                              </div>
-                            </TabsContent>
-                          );
-                        })}
-                        <TabsContent value={"case-custom"}>
-                            <div className="space-y-4">
-                              <CustomInput input={input} onChange={setInput} />
-                              {customInputLoading ? (
-                                <div className="flex items-center gap-2 text-muted-foreground">
-                                  <Icons.loader className="w-4 h-4 animate-spin" />
-                                  <span className="text-sm">Running...</span>
-                                </div>
-                              ) : (
-                                <>
-                                  <CustomInputResult result={customInputResult?.stdout ?? ""} />
-                                  {customInputResult?.stderr && (
-                                    <div className="space-y-2">
-                                      <label className="text-sm font-medium text-red-500 block">
-                                        Error Output
-                                      </label>
-                                      <Output output={customInputResult.stderr} />
-                                    </div>
-                                  )}
-                                </>
-                              )}
-                            </div>
-                          </TabsContent>
-
-                          {hiddenTestCases.length > 0 && (
-                            <TabsContent value="hidden-tests">
-                              <div className="space-y-3">
-                                <div className="grid gap-2">
-                                  {hiddenTestCases.map((testCase, index) => {
-                                    const testCaseResult = currentSubmissionDetails?.test_case_results?.find(
-                                      (r) => r.test_case_id === testCase.id
-                                    );
-
-                                    let hiddenStatus: "passed" | "failed" | "unknown" = "unknown";
-                                    if (currentSubmissionDetails && testCaseResult) {
-                                      hiddenStatus = testCaseResult.passed ? "passed" : "failed";
-                                    } else if (currentSubmissionDetails?.status === "ACCEPTED") {
-                                      hiddenStatus = "passed";
-                                    }
-
-                                    return (
-                                      <div
-                                        key={testCase.id}
-                                        className={cn(
-                                          "flex items-center justify-between p-3 rounded-lg border",
-                                          "bg-muted/30 backdrop-blur-sm",
-                                          hiddenStatus === "passed" && "border-green-500/30 bg-green-500/5",
-                                          hiddenStatus === "failed" && "border-red-500/30 bg-red-500/5",
-                                          hiddenStatus === "unknown" && "border-border"
-                                        )}
-                                      >
-                                        <div className="flex items-center gap-3">
-                                          <div className={cn(
-                                            "w-8 h-8 rounded-md flex items-center justify-center",
-                                            "bg-muted/50 text-muted-foreground",
-                                            hiddenStatus === "passed" && "bg-green-500/10 text-green-500",
-                                            hiddenStatus === "failed" && "bg-red-500/10 text-red-500"
-                                          )}>
-                                            {hiddenStatus === "passed" ? (
-                                              <Icons.check className="w-4 h-4" />
-                                            ) : hiddenStatus === "failed" ? (
-                                              <Icons.close className="w-4 h-4" />
-                                            ) : (
-                                              <Icons.lock className="w-3.5 h-3.5" />
-                                            )}
-                                          </div>
-                                          <div className="flex flex-col">
-                                            <span className="text-sm font-medium text-foreground">
-                                              Hidden Test {index + 1}
-                                            </span>
-                                            <span className="text-xs text-muted-foreground">
-                                              Input & output hidden
-                                            </span>
-                                          </div>
-                                        </div>
-
-                                        <div className="flex items-center gap-2">
-                                          {hiddenStatus !== "unknown" && (
-                                            <span className={cn(
-                                              "text-xs font-medium px-2 py-1 rounded-full",
-                                              hiddenStatus === "passed" && "bg-green-500/10 text-green-500",
-                                              hiddenStatus === "failed" && "bg-red-500/10 text-red-500"
-                                            )}>
-                                              {hiddenStatus === "passed" ? "Passed" : "Failed"}
-                                            </span>
-                                          )}
-                                        </div>
-                                      </div>
-                                    );
-                                  })}
-                                </div>
-                              </div>
-                            </TabsContent>
-                          )}
-                      </Tabs>
-                    </div>
-                  </div>
-                </ResizablePanel>
-              </ResizablePanelGroup>
-            </ResizablePanel>
-          </ResizablePanelGroup>
-        )}
+          </ResizablePanel>
+        </ResizablePanelGroup>
       </div>
     </TooltipProvider>
   );

--- a/src/web/src/components/editor/editor-layout.tsx
+++ b/src/web/src/components/editor/editor-layout.tsx
@@ -102,7 +102,7 @@ export default function EditorComponent({
     useState<CustomInputResultType | null>(null);
 
   useEffect(() => {
-    const workspace = document.querySelector(".editor-workspace");
+    const workspace = document.querySelector<HTMLElement>(".editor-workspace");
     if (!workspace) {
       return;
     }

--- a/src/web/src/components/editor/editor-nav.tsx
+++ b/src/web/src/components/editor/editor-nav.tsx
@@ -2,8 +2,8 @@
 
 import { Icons } from "@/components/icons";
 import { MainNavigationMenu } from "@/components/nav/navbar";
-import { ModeToggle } from "@/components/theme";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
   SheetContent,
@@ -11,76 +11,91 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { routeList } from "@/lib/constants";
-import { Menu } from "lucide-react";
+import { ChevronLeft, Menu } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 
 export default function EditorNavbar({
   children,
   notificationSlot,
+  backHref = "/platform/problems",
 }: {
   children: React.ReactNode;
-    notificationSlot: React.ReactNode;
+  notificationSlot: React.ReactNode;
+  backHref?: string;
 }) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
+
   return (
-    <header className="border-b-[1px] top-0 z-40 w-full bg-white dark:border-b-neutral-500/40 dark:bg-background">
-      <div className="container h-14 px-4 w-full flex justify-between">
-        <div className="font-bold flex items-center mx-6 gap-2">
-          <Icons.logo className="text-orange-600 w-6 h-6" />
-          <a href="/" className="text-xl">
-            NextJudge
-          </a>
-        </div>
-
-        {/* <EditorThemeSelector
-          onSelect={onSelect}
-          themes={themes}
-          selectedTheme={selectedTheme}
-        /> */}
-
-        {/* mobile */}
-        <div className="flex md:hidden items-center justify-center gap-8 mx-4">
-          <ModeToggle />
-          <Sheet open={isOpen} onOpenChange={setIsOpen}>
-            <SheetTrigger className="px-2" asChild>
-              <Button variant="ghost">
-                <Menu className="h-5 w-5" onClick={() => setIsOpen(true)} />
+    <TooltipProvider delayDuration={100}>
+      <nav className="flex w-full justify-between items-center h-12 shrink-0">
+        <div className="flex items-center h-8 space-x-1 min-w-0">
+          <Link href="/" className="flex items-center gap-2 mx-2">
+            <Icons.logo className="text-orange-600 w-7 h-7 shrink-0" />
+            <span className="text-lg font-bold hidden sm:inline">NextJudge</span>
+          </Link>
+          <Separator orientation="vertical" className="h-5" />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
+                <Link href={backHref}>
+                  <ChevronLeft className="h-4 w-4" />
+                </Link>
               </Button>
-            </SheetTrigger>
-
-            <SheetContent side={"left"}>
-              <SheetHeader>
-                <SheetTitle className="font-bold text-xl">NextJudge</SheetTitle>
-              </SheetHeader>
-              <nav className="flex flex-col justify-center items-center gap-2 mt-4">
-                {routeList.map(({ href, label }) => {
-                  const isExternal = href.startsWith("http");
-                  return (
-                    <a
-                      key={label}
-                      href={href}
-                      target={isExternal ? "_blank" : undefined}
-                      rel={isExternal ? "noopener noreferrer" : undefined}
-                      onClick={() => setIsOpen(false)}
-                      className={buttonVariants({ variant: "ghost" })}
-                    >
-                      {label}
-                    </a>
-                  );
-                })}
-              </nav>
-            </SheetContent>
-          </Sheet>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Back to problems</p>
+            </TooltipContent>
+          </Tooltip>
         </div>
 
-        <div className="hidden md:flex flex-row gap-4 justify-center items-center mx-12 ">
-          <MainNavigationMenu />
-          {notificationSlot}
-          {children}
-          <ModeToggle />
+        <div className="flex items-center h-8 space-x-1">
+          <div className="hidden md:flex items-center gap-2">
+            <MainNavigationMenu />
+            {notificationSlot}
+            {children}
+          </div>
+
+          <div className="flex md:hidden items-center gap-1">
+            <Sheet open={isOpen} onOpenChange={setIsOpen}>
+              <SheetTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Menu className="h-5 w-5" />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left">
+                <SheetHeader>
+                  <SheetTitle className="font-bold text-xl">NextJudge</SheetTitle>
+                </SheetHeader>
+                <nav className="flex flex-col justify-center items-center gap-2 mt-4">
+                  {routeList.map(({ href, label }) => {
+                    const isExternal = href.startsWith("http");
+                    return (
+                      <a
+                        key={label}
+                        href={href}
+                        target={isExternal ? "_blank" : undefined}
+                        rel={isExternal ? "noopener noreferrer" : undefined}
+                        onClick={() => setIsOpen(false)}
+                        className={buttonVariants({ variant: "ghost" })}
+                      >
+                        {label}
+                      </a>
+                    );
+                  })}
+                </nav>
+              </SheetContent>
+            </Sheet>
+          </div>
         </div>
-      </div>
-    </header>
+      </nav>
+    </TooltipProvider>
   );
 }

--- a/src/web/src/components/editor/editor-theme-select.tsx
+++ b/src/web/src/components/editor/editor-theme-select.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from "@/lib/utils";
 import { ThemeContext } from "@/providers/editor-theme";
 import { CaretSortIcon, CheckIcon } from "@radix-ui/react-icons";
+import { Palette } from "lucide-react";
 import * as React from "react";
 
 export type Theme = {
@@ -23,7 +24,13 @@ export type Theme = {
   fetch: string;
 };
 
-export function EditorThemeSelector({ themes }: { themes: Theme[] }) {
+export function EditorThemeSelector({
+  themes,
+  variant = "default",
+}: {
+  themes: Theme[];
+  variant?: "default" | "compact";
+}) {
   const { theme: currentTheme, setTheme } = React.useContext(ThemeContext);
   const [open, setOpen] = React.useState(false);
   const builtInThemes: Theme[] = [
@@ -33,24 +40,38 @@ export function EditorThemeSelector({ themes }: { themes: Theme[] }) {
 
   const allThemes = [...builtInThemes, ...themes];
 
+  const isCompact = variant === "compact";
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
-          variant="outline"
+          variant={isCompact ? "ghost" : "outline"}
           role="combobox"
           aria-expanded={open}
-          className="w-[200px] justify-between"
+          className={cn(
+            isCompact
+              ? "h-6 w-6 p-1"
+              : "w-[200px] justify-between"
+          )}
+          title="Editor theme"
+          aria-label="Editor theme"
         >
-          {currentTheme?.name ? (
-            currentTheme.name === "vs-dark" ? "VS Code Dark" :
-              currentTheme.name === "light" ? "VS Code Light" :
-                currentTheme.name
-          ) : "Select theme..."}
-          <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          {isCompact ? (
+            <Palette className="!w-3.5 !h-3.5" />
+          ) : (
+            <>
+              {currentTheme?.name ? (
+                currentTheme.name === "vs-dark" ? "VS Code Dark" :
+                  currentTheme.name === "light" ? "VS Code Light" :
+                    currentTheme.name
+              ) : "Select theme..."}
+              <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </>
+          )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-0">
+      <PopoverContent className={cn(isCompact ? "w-[220px] p-0" : "w-[200px] p-0")}>
         <Command>
           <CommandInput placeholder="Search our themes..." className="h-9" />
           <CommandEmpty>No theme found.</CommandEmpty>

--- a/src/web/src/components/editor/output-diff.tsx
+++ b/src/web/src/components/editor/output-diff.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { useMemo, type ReactNode } from "react";
+
+type SegmentKind = "match" | "missing" | "extra";
+
+interface AlignedSegment {
+  text: string;
+  kind: SegmentKind;
+}
+
+function groupSegments(
+  text: string,
+  getKind: (index: number) => SegmentKind
+): AlignedSegment[] {
+  if (text.length === 0) return [];
+
+  const segments: AlignedSegment[] = [];
+  let buffer = "";
+  let currentKind = getKind(0);
+
+  const flush = () => {
+    if (buffer.length > 0) {
+      segments.push({ text: buffer, kind: currentKind });
+      buffer = "";
+    }
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const kind = getKind(i);
+    if (kind !== currentKind) {
+      flush();
+      currentKind = kind;
+    }
+    buffer += text[i];
+  }
+
+  flush();
+  return segments;
+}
+
+function buildExpectedSegments(expected: string, actual: string): AlignedSegment[] {
+  return groupSegments(expected, (index) => {
+    if (index < actual.length && expected[index] === actual[index]) {
+      return "match";
+    }
+    return "missing";
+  });
+}
+
+function buildActualSegments(expected: string, actual: string): AlignedSegment[] {
+  return groupSegments(actual, (index) => {
+    if (index < expected.length && expected[index] === actual[index]) {
+      return "match";
+    }
+    return "extra";
+  });
+}
+
+function buildLineAlignedSegments(
+  expected: string,
+  actual: string,
+  side: "expected" | "actual"
+): AlignedSegment[] {
+  const expectedLines = expected.split("\n");
+  const actualLines = actual.split("\n");
+  const lineCount = Math.max(expectedLines.length, actualLines.length);
+  const segments: AlignedSegment[] = [];
+
+  for (let line = 0; line < lineCount; line++) {
+    if (line > 0) {
+      segments.push({ text: "\n", kind: "match" });
+    }
+
+    const expectedLine = expectedLines[line] ?? "";
+    const actualLine = actualLines[line] ?? "";
+    const lineSegments =
+      side === "expected"
+        ? buildExpectedSegments(expectedLine, actualLine)
+        : buildActualSegments(expectedLine, actualLine);
+
+    segments.push(...lineSegments);
+  }
+
+  return segments;
+}
+
+function computeAlignedSegments(
+  expected: string,
+  actual: string,
+  side: "expected" | "actual"
+): AlignedSegment[] {
+  if (expected.includes("\n") || actual.includes("\n")) {
+    return buildLineAlignedSegments(expected, actual, side);
+  }
+
+  return side === "expected"
+    ? buildExpectedSegments(expected, actual)
+    : buildActualSegments(expected, actual);
+}
+
+function DiffCard({ children }: { children: ReactNode }) {
+  return (
+    <Card className="overflow-hidden border border-border/50 bg-muted/30">
+      <div className="px-3 py-3 font-mono whitespace-pre-wrap break-all leading-6 text-foreground select-all">
+        {children}
+      </div>
+    </Card>
+  );
+}
+
+function ExpectedDiffView({ segments }: { segments: AlignedSegment[] }) {
+  return (
+    <>
+      {segments.map((segment, index) => {
+        if (segment.kind === "missing") {
+          return (
+            <span
+              key={index}
+              className="text-destructive line-through decoration-destructive/80 bg-destructive/15"
+            >
+              {segment.text}
+            </span>
+          );
+        }
+        return <span key={index}>{segment.text}</span>;
+      })}
+    </>
+  );
+}
+
+function ActualDiffView({ segments }: { segments: AlignedSegment[] }) {
+  return (
+    <>
+      {segments.map((segment, index) => {
+        if (segment.kind === "extra") {
+          return (
+            <span key={index} className="text-destructive bg-destructive/15">
+              {segment.text}
+            </span>
+          );
+        }
+        return <span key={index}>{segment.text}</span>;
+      })}
+    </>
+  );
+}
+
+export function OutputComparison({
+  expected,
+  actual,
+}: {
+  expected: string;
+  actual: string;
+}) {
+  const expectedSegments = useMemo(
+    () => computeAlignedSegments(expected, actual, "expected"),
+    [expected, actual]
+  );
+  const actualSegments = useMemo(
+    () => computeAlignedSegments(expected, actual, "actual"),
+    [expected, actual]
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <p className="text-xs text-muted-foreground">Expected Output</p>
+        <DiffCard>
+          <ExpectedDiffView segments={expectedSegments} />
+        </DiffCard>
+      </div>
+      <div className="space-y-1.5">
+        <p className="text-xs text-muted-foreground">Your Output</p>
+        <DiffCard>
+          <ActualDiffView segments={actualSegments} />
+        </DiffCard>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/editor/problem-section.tsx
+++ b/src/web/src/components/editor/problem-section.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { RecentSubmissionCard } from "@/app/platform/problems/components/recent-submissions";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { Problem, Submission } from "@/lib/types";
+import { Tag } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+interface ProblemSectionProps {
+  details: Problem;
+  tags: string[];
+  slot: React.ReactNode;
+  recentSubmissions: Submission[];
+}
+
+function formatDifficulty(difficulty?: string) {
+  if (!difficulty) return "Unknown";
+  return difficulty.charAt(0) + difficulty.slice(1).toLowerCase();
+}
+
+export function ProblemSection({
+  details,
+  tags,
+  slot,
+  recentSubmissions,
+}: ProblemSectionProps) {
+  const router = useRouter();
+
+  return (
+    <Tabs defaultValue="description" className="h-full flex flex-col">
+      <TabsList className="flex justify-start w-full h-9 shrink-0 rounded-none bg-muted/40 p-1 mx-0">
+        <TabsTrigger value="description" className="px-2 py-1 h-7">
+          Description
+        </TabsTrigger>
+        <TabsTrigger value="submissions" className="px-2 py-1 h-7">
+          Submissions
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="description" className="flex-1 min-h-0 mt-0 data-[state=inactive]:hidden select-none">
+        <div className="flex flex-col h-full">
+          <ScrollArea className="flex-1">
+            <div className="flex flex-col p-4">
+              <div className="flex justify-between items-center pt-1">
+                <h1 className="text-2xl font-bold">
+                  {details.id > 0 ? `${details.id}. ` : ""}
+                  {details.title}
+                </h1>
+              </div>
+              <div className="flex items-center flex-wrap gap-2 my-4">
+                <Button size="sm" variant="secondary" className="h-7">
+                  {formatDifficulty(details.difficulty)}
+                </Button>
+                {tags.length > 0 && (
+                  <Button size="sm" variant="secondary" className="h-7 gap-1">
+                    <Tag className="!w-3" /> Topics
+                  </Button>
+                )}
+              </div>
+              {tags.length > 0 && (
+                <div className="flex flex-wrap gap-2 mb-4">
+                  {tags.map((tag) => (
+                    <button
+                      key={tag}
+                      type="button"
+                      onClick={() => router.push(`/platform/problems?tag=${tag.toLowerCase()}`)}
+                      className="text-xs px-2 py-1 rounded-md bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <div className="editor-prose flex flex-col space-y-3 text-sm">{slot}</div>
+            </div>
+          </ScrollArea>
+        </div>
+      </TabsContent>
+      <TabsContent value="submissions" className="flex-1 min-h-0 mt-0 data-[state=inactive]:hidden">
+        <ScrollArea className="h-full">
+          <div className="p-4">
+            {recentSubmissions.length > 0 ? (
+              <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {recentSubmissions.map((submission) => (
+                  <RecentSubmissionCard submission={submission} key={submission.id} />
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">No submissions yet.</p>
+            )}
+          </div>
+        </ScrollArea>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/web/src/components/editor/testcase-section.tsx
+++ b/src/web/src/components/editor/testcase-section.tsx
@@ -1,0 +1,502 @@
+"use client";
+
+import { Icons } from "@/components/icons";
+import {
+  CustomInput,
+  CustomInputResult,
+  Expected,
+  Input as InputCase,
+  Output,
+} from "@/components/submit-box";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Tabs as CaseTabs,
+  TabsContent as CaseTabsContent,
+  TabsList as CaseTabsList,
+  TabsTrigger as CaseTabsTrigger,
+} from "@/components/ui/testcase-tabs";
+import type {
+  CustomInputResult as CustomInputResultType,
+  PracticeRunResult,
+  Submission,
+  SubmissionStatus,
+  TestCase,
+} from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Check, Loader2, Plus, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { SubmissionState } from "./editor-submission-state";
+import { OutputComparison } from "./output-diff";
+
+interface TestcaseSectionProps {
+  publicTestCases: TestCase[];
+  hiddenTestCases: TestCase[];
+  input: string;
+  setInput: (value: string) => void;
+  activeCaseTab: string;
+  onActiveCaseTabChange: (tab: string) => void;
+  runLoading: boolean;
+  runResults: PracticeRunResult | null;
+  runningCaseIndex: number | null;
+  customInputResult: CustomInputResultType | null;
+  submissionLoading: boolean;
+  submissionError: string;
+  currentSubmissionDetails: Submission | null;
+}
+
+type CaseRunStatus = "idle" | "running" | "passed" | "failed" | "skipped";
+
+function shouldShowOutputDiff(
+  status: CaseRunStatus,
+  stdout?: string,
+  stderr?: string,
+  compileStderr?: string
+): boolean {
+  if (status !== "failed") return false;
+  if (isExecutionError(stderr, compileStderr)) return false;
+  return !(compileStderr && !stdout);
+}
+
+function isExecutionError(stderr?: string, compileStderr?: string): boolean {
+  return Boolean(stderr?.trim()) || Boolean(compileStderr?.trim());
+}
+
+function getCaseRunStatus(
+  index: number,
+  testCaseId: string,
+  runLoading: boolean,
+  runningCaseIndex: number | null,
+  runResults: PracticeRunResult | null,
+  submission: Submission | null,
+  publicTestCases: TestCase[]
+): CaseRunStatus {
+  if (runLoading && runningCaseIndex === index) return "running";
+
+  const runResult = runResults?.test_case_results.find(
+    (r) => r.test_case_id === testCaseId
+  );
+  if (runResult) return runResult.passed ? "passed" : "failed";
+
+  if (runResults?.status === "COMPILE_TIME_ERROR") {
+    return index === 0 ? "failed" : "skipped";
+  }
+
+  if (runLoading && runningCaseIndex !== null && index > runningCaseIndex) {
+    return "idle";
+  }
+
+  if (submission && !runResults) {
+    const testCaseResult = submission.test_case_results?.find(
+      (r) => r.test_case_id === testCaseId
+    );
+    if (testCaseResult) {
+      return testCaseResult.passed ? "passed" : "failed";
+    }
+    if (submission.status === "ACCEPTED") return "passed";
+
+    const isFailedTestCase = submission.failed_test_case_id === testCaseId;
+    if (isFailedTestCase) return "failed";
+
+    const failedTestCaseIndex = submission.failed_test_case_id
+      ? publicTestCases.findIndex((tc) => tc.id === submission.failed_test_case_id)
+      : -1;
+    if (failedTestCaseIndex !== -1 && failedTestCaseIndex > index) {
+      return "passed";
+    }
+
+    if (submission.status === "COMPILE_TIME_ERROR") {
+      return index === 0 ? "failed" : "skipped";
+    }
+
+    return "skipped";
+  }
+
+  return "idle";
+}
+
+function getCaseOutput(
+  testCaseId: string,
+  index: number,
+  runResults: PracticeRunResult | null,
+  submission: Submission | null
+): {
+  stdout?: string;
+  stderr?: string;
+  compileStderr?: string;
+} {
+  const runResult = runResults?.test_case_results.find(
+    (r) => r.test_case_id === testCaseId
+  );
+  if (runResult) {
+    const isCompileError =
+      runResults?.status === "COMPILE_TIME_ERROR" && index === 0;
+    return {
+      stdout: runResult.stdout,
+      stderr: runResult.stderr,
+      compileStderr: isCompileError ? runResults.stderr : undefined,
+    };
+  }
+
+  if (!submission) return {};
+
+  const testCaseResult = submission.test_case_results?.find(
+    (r) => r.test_case_id === testCaseId
+  );
+  const isFailedTestCase = submission.failed_test_case_id === testCaseId;
+  const isCompileError = submission.status === "COMPILE_TIME_ERROR";
+
+  return {
+    stdout: testCaseResult?.stdout,
+    stderr:
+      testCaseResult?.stderr ??
+      (isFailedTestCase || isCompileError ? submission.stderr : undefined),
+    compileStderr:
+      isCompileError && index === 0 ? submission.stderr : undefined,
+  };
+}
+
+function CaseStatusIcon({ status }: { status: CaseRunStatus }) {
+  if (status === "running") {
+    return <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />;
+  }
+  if (status === "passed") {
+    return <Check className="h-3 w-3 text-[var(--success-green)]" strokeWidth={2.5} />;
+  }
+  if (status === "failed") {
+    return <X className="h-3 w-3 text-destructive" strokeWidth={2.5} />;
+  }
+  return null;
+}
+
+function CaseRunOutput({
+  status,
+  expected,
+  stdout,
+  stderr,
+  compileStderr,
+  showDiff,
+}: {
+  status: CaseRunStatus;
+  expected?: string;
+  stdout?: string;
+  stderr?: string;
+  compileStderr?: string;
+  showDiff: boolean;
+}) {
+  if (status === "idle" || status === "running" || status === "skipped") {
+    return null;
+  }
+
+  const isCompileError = status === "failed" && Boolean(compileStderr?.trim());
+  const isRuntimeError = status === "failed" && Boolean(stderr?.trim()) && !isCompileError;
+  const isExecutionErrorResult = isCompileError || isRuntimeError;
+  const isWrongAnswer =
+    status === "failed" && !isExecutionErrorResult && expected !== undefined;
+  const errorOutput = stderr || (isCompileError ? compileStderr : undefined);
+
+  const failureLabel = isCompileError
+    ? "Compilation failed"
+    : isRuntimeError
+      ? "Runtime error"
+      : status === "passed"
+        ? "Accepted"
+        : "Wrong answer";
+
+  return (
+    <div
+      className={cn(
+        "space-y-3 rounded-lg border px-3 py-3",
+        status === "passed" && "border-[var(--success-green)]/25 bg-[var(--success-green)]/5",
+        status === "failed" && "border-destructive/25 bg-destructive/5"
+      )}
+    >
+      <div className="flex items-center gap-2">
+        {status === "passed" ? (
+          <Check className="h-3.5 w-3.5 text-[var(--success-green)]" strokeWidth={2.5} />
+        ) : (
+          <X className="h-3.5 w-3.5 text-destructive" strokeWidth={2.5} />
+        )}
+        <p
+          className={cn(
+            "text-xs font-medium",
+            status === "passed" && "text-[var(--success-green)]",
+            status === "failed" && "text-destructive"
+          )}
+        >
+          {failureLabel}
+        </p>
+      </div>
+
+      {isExecutionErrorResult && stdout && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">Your output</p>
+          <Output output={stdout} />
+        </div>
+      )}
+
+      {isWrongAnswer && showDiff && (
+        <OutputComparison expected={expected} actual={stdout ?? ""} />
+      )}
+
+      {isWrongAnswer && !showDiff && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">Your output</p>
+          <Output output={stdout ?? ""} />
+        </div>
+      )}
+
+      {status === "passed" && stdout && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">Your output</p>
+          <Output output={stdout} />
+        </div>
+      )}
+
+      {errorOutput && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-destructive">Error output</p>
+          <Output output={errorOutput} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HiddenTestsNotice({ count }: { count: number }) {
+  if (count === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <Icons.lock className="h-3.5 w-3.5" />
+      <span>{count} hidden</span>
+    </div>
+  );
+}
+
+function formatCustomOutput(result: CustomInputResultType): string {
+  if (result.stderr) return result.stderr;
+  if (result.stdout) return result.stdout;
+
+  const statusMessages: Partial<Record<SubmissionStatus, string>> = {
+    TIME_LIMIT_EXCEEDED: "Time limit exceeded",
+    MEMORY_LIMIT_EXCEEDED: "Memory limit exceeded",
+    RUNTIME_ERROR: "Runtime error",
+    COMPILE_TIME_ERROR: "Compilation error",
+    WRONG_ANSWER: "Wrong answer",
+  };
+
+  return statusMessages[result.status] ?? "";
+}
+
+export function TestcaseSection({
+  publicTestCases,
+  hiddenTestCases,
+  input,
+  setInput,
+  activeCaseTab,
+  onActiveCaseTabChange,
+  runLoading,
+  runResults,
+  runningCaseIndex,
+  customInputResult,
+  submissionLoading,
+  submissionError,
+  currentSubmissionDetails,
+}: TestcaseSectionProps) {
+  const isRunningCustom = runLoading && activeCaseTab === "case-custom";
+
+  const passedCount =
+    runResults?.test_case_results.filter((r) => r.passed).length ?? 0;
+  const hasRunResults = runResults !== null && !runLoading;
+  const showSubmissionResults =
+    currentSubmissionDetails !== null && !submissionLoading && !runResults;
+  const [showDiff, setShowDiff] = useState(true);
+
+  const hasWrongAnswerOutput = useMemo(
+    () =>
+      publicTestCases.some((testCase, index) => {
+        const status = getCaseRunStatus(
+          index,
+          testCase.id,
+          runLoading,
+          runningCaseIndex,
+          runResults,
+          currentSubmissionDetails,
+          publicTestCases
+        );
+        const { stdout, stderr, compileStderr } = getCaseOutput(
+          testCase.id,
+          index,
+          runResults,
+          currentSubmissionDetails
+        );
+        return shouldShowOutputDiff(status, stdout, stderr, compileStderr);
+      }),
+    [
+      publicTestCases,
+      runLoading,
+      runningCaseIndex,
+      runResults,
+      currentSubmissionDetails,
+    ]
+  );
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-2 h-9 shrink-0 rounded-none bg-muted/40 px-3">
+        <span className="text-sm font-medium">Testcase</span>
+        {hasRunResults && (
+          <span
+            className={cn(
+              "text-[10px] font-medium tabular-nums",
+              runResults.status === "ACCEPTED"
+                ? "text-[var(--success-green)]"
+                : "text-destructive"
+            )}
+          >
+            {passedCount}/{publicTestCases.length}
+          </span>
+        )}
+        {hasWrongAnswerOutput && (
+          <label className="ml-auto flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+            <Checkbox
+              id="show-output-diff"
+              checked={showDiff}
+              onCheckedChange={(checked) => setShowDiff(checked === true)}
+              className="h-3.5 w-3.5"
+            />
+            Show diff
+          </label>
+        )}
+      </div>
+
+      <ScrollArea className="flex-1 min-h-0">
+        <div className="px-5 py-4 space-y-4">
+          {submissionLoading && (
+            <div className="flex items-center gap-2 text-yellow-500">
+              <Icons.loader className="w-5 h-5 animate-spin" />
+              <span className="font-medium">Pending...</span>
+            </div>
+          )}
+
+          {submissionError && (
+            <p className="text-sm text-destructive">{submissionError}</p>
+          )}
+
+          {showSubmissionResults && currentSubmissionDetails && (
+            <SubmissionState submission={currentSubmissionDetails} />
+          )}
+
+          <CaseTabs
+            value={activeCaseTab}
+            onValueChange={onActiveCaseTabChange}
+          >
+            <div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-none">
+              <CaseTabsList className="inline-flex h-8 w-auto shrink-0 gap-1 bg-transparent p-0">
+                {publicTestCases.map((testCase, index) => {
+                  const status = getCaseRunStatus(
+                    index,
+                    testCase.id,
+                    runLoading,
+                    runningCaseIndex,
+                    runResults,
+                    currentSubmissionDetails,
+                    publicTestCases
+                  );
+
+                  return (
+                    <CaseTabsTrigger
+                      key={index}
+                      value={`case-${index}`}
+                      className={cn(
+                        "gap-1.5",
+                        status === "passed" &&
+                          "data-[state=inactive]:border-[var(--success-green)]/40 data-[state=inactive]:text-[var(--success-green)]",
+                        status === "failed" &&
+                          "data-[state=inactive]:border-destructive/40 data-[state=inactive]:text-destructive"
+                      )}
+                    >
+                      <span>Case {index + 1}</span>
+                      <CaseStatusIcon status={status} />
+                    </CaseTabsTrigger>
+                  );
+                })}
+                <CaseTabsTrigger value="case-custom" className="gap-1">
+                  <Plus className="h-3 w-3" />
+                  Custom
+                </CaseTabsTrigger>
+              </CaseTabsList>
+            </div>
+
+            {publicTestCases.map((testCase, index) => {
+              const status = getCaseRunStatus(
+                index,
+                testCase.id,
+                runLoading,
+                runningCaseIndex,
+                runResults,
+                currentSubmissionDetails,
+                publicTestCases
+              );
+              const { stdout, stderr, compileStderr } = getCaseOutput(
+                testCase.id,
+                index,
+                runResults,
+                currentSubmissionDetails
+              );
+              const showOutputDiff = shouldShowOutputDiff(
+                status,
+                stdout,
+                stderr,
+                compileStderr
+              );
+
+              return (
+                <CaseTabsContent
+                  key={testCase.id}
+                  value={`case-${index}`}
+                  className="mt-0 space-y-4"
+                >
+                  <InputCase input={testCase.input} />
+                  {!(showOutputDiff && showDiff) && (
+                    <Expected expected={testCase.expected_output} />
+                  )}
+                  {status === "running" && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      Running...
+                    </div>
+                  )}
+                  <CaseRunOutput
+                    status={status}
+                    expected={testCase.expected_output}
+                    stdout={stdout}
+                    stderr={stderr}
+                    compileStderr={compileStderr}
+                    showDiff={showDiff}
+                  />
+                </CaseTabsContent>
+              );
+            })}
+
+            <CaseTabsContent value="case-custom" className="mt-0 space-y-4">
+              <CustomInput input={input} onChange={setInput} />
+              {isRunningCustom && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Running...
+                </div>
+              )}
+              {customInputResult && !isRunningCustom && (
+                <CustomInputResult result={formatCustomOutput(customInputResult)} />
+              )}
+            </CaseTabsContent>
+          </CaseTabs>
+
+          <HiddenTestsNotice count={hiddenTestCases.length} />
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/web/src/components/nav/main-navigation-menu.tsx
+++ b/src/web/src/components/nav/main-navigation-menu.tsx
@@ -22,11 +22,11 @@ export function MainNavigationMenu({ session }: { session: Session | undefined }
   });
 
   return (
-    <NavigationMenu>
+    <NavigationMenu viewport={false}>
       <NavigationMenuList>
-        <NavigationMenuItem>
+        <NavigationMenuItem className="relative">
           <NavigationMenuTrigger>{infos.title}</NavigationMenuTrigger>
-          <NavigationMenuContent>
+          <NavigationMenuContent className="left-auto right-0 top-full mt-1.5 rounded-md border bg-popover text-popover-foreground shadow">
             <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
               <li className="row-span-3">
                 <a

--- a/src/web/src/components/ui/navigation-menu.tsx
+++ b/src/web/src/components/ui/navigation-menu.tsx
@@ -5,20 +5,30 @@ import { cva } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
+type NavigationMenuViewportAlign = "center" | "end"
+
+interface NavigationMenuProps
+  extends React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root> {
+  viewportAlign?: NavigationMenuViewportAlign
+  viewport?: boolean
+}
+
 const NavigationMenu = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  NavigationMenuProps
+>(({ className, children, viewportAlign = "center", viewport = true, ...props }, ref) => (
   <NavigationMenuPrimitive.Root
     ref={ref}
+    viewport={viewport}
     className={cn(
-      "relative z-10 flex max-w-max flex-1 items-center justify-center",
+      "relative z-10 flex max-w-max flex-1 items-center",
+      viewportAlign === "end" ? "justify-end" : "justify-center",
       className
     )}
     {...props}
   >
     {children}
-    <NavigationMenuViewport />
+    {viewport ? <NavigationMenuViewport align={viewportAlign} /> : null}
   </NavigationMenuPrimitive.Root>
 ))
 NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName
@@ -79,11 +89,21 @@ NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName
 
 const NavigationMenuLink = NavigationMenuPrimitive.Link
 
+interface NavigationMenuViewportProps
+  extends React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport> {
+  align?: NavigationMenuViewportAlign
+}
+
 const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
->(({ className, ...props }, ref) => (
-  <div className={cn("absolute left-0 top-full flex justify-center")}>
+  NavigationMenuViewportProps
+>(({ className, align = "center", ...props }, ref) => (
+  <div
+    className={cn(
+      "absolute top-full flex",
+      align === "end" ? "right-0 justify-end" : "left-0 justify-center"
+    )}
+  >
     <NavigationMenuPrimitive.Viewport
       className={cn(
         "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",

--- a/src/web/src/components/ui/navigation-menu.tsx
+++ b/src/web/src/components/ui/navigation-menu.tsx
@@ -19,7 +19,6 @@ const NavigationMenu = React.forwardRef<
 >(({ className, children, viewportAlign = "center", viewport = true, ...props }, ref) => (
   <NavigationMenuPrimitive.Root
     ref={ref}
-    viewport={viewport}
     className={cn(
       "relative z-10 flex max-w-max flex-1 items-center",
       viewportAlign === "end" ? "justify-end" : "justify-center",

--- a/src/web/src/components/ui/testcase-tabs.tsx
+++ b/src/web/src/components/ui/testcase-tabs.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex items-center gap-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex h-7 shrink-0 items-center justify-center whitespace-nowrap rounded-md border border-transparent px-2.5 text-xs font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+      "data-[state=active]:border-border/60 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/web/src/lib/types.ts
+++ b/src/web/src/lib/types.ts
@@ -218,6 +218,19 @@ export interface CustomInputResult {
 	runtime: number;
 }
 
+export interface PracticeRunTestCaseResult {
+	test_case_id: string;
+	stdout: string;
+	stderr: string;
+	passed: boolean;
+}
+
+export interface PracticeRunResult {
+	status: SubmissionStatus;
+	test_case_results: PracticeRunTestCaseResult[];
+	stderr?: string;
+}
+
 
 // export interface Competition {
 //     id: number;

--- a/src/web/src/lib/utils.ts
+++ b/src/web/src/lib/utils.ts
@@ -34,3 +34,20 @@ export function convertToMonacoLanguageName(language: Language | undefined) {
 
     return language.name.toLowerCase();
 }
+
+export function compareOutput(expected: string, actual: string): boolean {
+    const expectedLines = expected.trim().split("\n").map((line) => line.trim());
+    const actualLines = actual.trim().split("\n").map((line) => line.trim());
+
+    if (expectedLines.length !== actualLines.length) {
+        return false;
+    }
+
+    for (let i = 0; i < expectedLines.length; i++) {
+        if (expectedLines[i] !== actualLines[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
Redesigns the problem editor UI (practice runs, testcase tabs, output diff) and hardens the submission pipeline so both problem and custom-input runs are persisted and reliably delivered to the judge.

**Backend (data-layer)**
- Adds `enqueue_state` tracking on submissions and a new `input_submissions` table
- Replaces the in-memory custom input map with database-backed records
- Introduces an enqueue reaper that retries failed RabbitMQ publishes on a 30s interval
- Hardens RabbitMQ with reconnect logic, publish retries, and a DLQ queue

**Judge**
- Fetches input submission source/stdin from the API instead of inline queue payloads
- Skips already-judged or finished submissions for idempotency
- Surfaces API errors as runtime failures instead of silently logging

**Web**
- Full-height editor layout with dark workspace theme
- New problem section, testcase tabs, and character-level output diff
- Practice run flow with per-testcase pass/fail visualization
- Nav menu dropdown positioning fix for the editor header