### PR TITLE
Add Coolify preview cleanup on PR close

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,37 @@
+name: Preview cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SSH key for preview cleanup
+        if: ${{ vars.COOLIFY_SSH_HOST != '' }}
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.COOLIFY_SSH_PRIVATE_KEY }}
+
+      - name: Add VPS host key
+        if: ${{ vars.COOLIFY_SSH_HOST != '' }}
+        run: |
+          host="${COOLIFY_SSH_HOST#*@}"
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "$host" >> ~/.ssh/known_hosts
+        env:
+          COOLIFY_SSH_HOST: ${{ vars.COOLIFY_SSH_HOST }}
+
+      - name: Remove Coolify preview for closed PR
+        env:
+          COOLIFY_API_URL: ${{ vars.COOLIFY_API_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          COOLIFY_WEB_APP_UUID: ${{ vars.COOLIFY_WEB_APP_UUID }}
+          COOLIFY_DOCS_APP_UUID: ${{ vars.COOLIFY_DOCS_APP_UUID }}
+          COOLIFY_SSH_HOST: ${{ vars.COOLIFY_SSH_HOST }}
+          COOLIFY_PREVIEW_USE_SSH: ${{ vars.COOLIFY_SSH_HOST != '' && '1' || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./scripts/coolify-preview-cleanup.sh "$PR_NUMBER"

--- a/scripts/coolify-preview-cleanup.sh
+++ b/scripts/coolify-preview-cleanup.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tear down Coolify PR preview deployments for web and/or docs.
+#
+# Usage:
+#   ./scripts/coolify-preview-cleanup.sh <PR_NUMBER>
+#   ./scripts/coolify-preview-cleanup.sh --all
+#
+# Required env (API path — Coolify v4 beta.474+):
+#   COOLIFY_API_URL
+#   COOLIFY_API_TOKEN
+#   COOLIFY_WEB_APP_UUID
+#   COOLIFY_DOCS_APP_UUID
+#
+# Optional (SSH fallback when preview DELETE API is unavailable):
+#   COOLIFY_SSH_HOST          e.g. nextjudge or user@77.42.27.51
+#   COOLIFY_PREVIEW_USE_SSH=1 force docker cleanup over SSH
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+}
+
+delete_preview_via_api() {
+  local app_uuid="$1"
+  local pr_number="$2"
+
+  local response http_code
+  response="$(
+    curl -sS -w "\n%{http_code}" -X DELETE \
+      "${COOLIFY_API_URL}/applications/${app_uuid}/previews/${pr_number}" \
+      -H "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
+      -H "Accept: application/json"
+  )"
+  http_code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+
+  case "$http_code" in
+    200)
+      echo "Queued Coolify preview deletion for app ${app_uuid} (PR #${pr_number})." >&2
+      return 0
+      ;;
+    404)
+      echo "Coolify preview API unavailable or no preview record for app ${app_uuid} (PR #${pr_number})." >&2
+      return 1
+      ;;
+    *)
+      echo "Coolify preview delete failed (${http_code}) for app ${app_uuid} (PR #${pr_number}): ${body}" >&2
+      return 1
+      ;;
+  esac
+}
+
+delete_preview_via_ssh() {
+  local pr_number="$1"
+  local ssh_host="${COOLIFY_SSH_HOST:?set COOLIFY_SSH_HOST for SSH fallback}"
+
+  echo "Removing preview containers over SSH for PR #${pr_number}..." >&2
+  ssh -o BatchMode=yes -o StrictHostKeyChecking=yes "$ssh_host" bash -s -- "$pr_number" <<'REMOTE'
+set -euo pipefail
+pr="$1"
+mapfile -t containers < <(docker ps -aq --filter "name=-pr-${pr}-" 2>/dev/null || true)
+if ((${#containers[@]} == 0)); then
+  echo "No preview containers found for PR #${pr}."
+  exit 0
+fi
+docker ps -a --filter "name=-pr-${pr}-" --format '{{.Names}}'
+docker rm -f "${containers[@]}"
+echo "Removed ${#containers[@]} container(s) for PR #${pr}."
+REMOTE
+}
+
+cleanup_pr() {
+  local pr_number="$1"
+
+  local api_ok=0
+  if [[ -n "${COOLIFY_API_URL:-}" && -n "${COOLIFY_API_TOKEN:-}" ]]; then
+    if [[ -n "${COOLIFY_WEB_APP_UUID:-}" ]]; then
+      delete_preview_via_api "$COOLIFY_WEB_APP_UUID" "$pr_number" || api_ok=1
+    fi
+    if [[ -n "${COOLIFY_DOCS_APP_UUID:-}" ]]; then
+      delete_preview_via_api "$COOLIFY_DOCS_APP_UUID" "$pr_number" || api_ok=1
+    fi
+  else
+    api_ok=1
+  fi
+
+  if [[ "$api_ok" -ne 0 || "${COOLIFY_PREVIEW_USE_SSH:-}" == "1" ]]; then
+    if [[ -n "${COOLIFY_SSH_HOST:-}" ]]; then
+      delete_preview_via_ssh "$pr_number"
+    elif [[ "$api_ok" -ne 0 ]]; then
+      echo "No working cleanup path for PR #${pr_number}. Set COOLIFY_SSH_HOST or upgrade Coolify for preview DELETE API." >&2
+      return 1
+    fi
+  fi
+}
+
+cleanup_all_via_ssh() {
+  local ssh_host="${COOLIFY_SSH_HOST:?set COOLIFY_SSH_HOST for --all}"
+
+  echo "Removing all preview containers over SSH..." >&2
+  ssh -o BatchMode=yes -o StrictHostKeyChecking=yes "$ssh_host" bash <<'REMOTE'
+set -euo pipefail
+mapfile -t containers < <(docker ps -aq --filter "name=-pr-" 2>/dev/null || true)
+if ((${#containers[@]} == 0)); then
+  echo "No preview containers found."
+  exit 0
+fi
+docker ps -a --filter "name=-pr-" --format '{{.Names}}'
+docker rm -f "${containers[@]}"
+echo "Removed ${#containers[@]} preview container(s)."
+REMOTE
+}
+
+main() {
+  local target="${1:?usage: coolify-preview-cleanup.sh <PR_NUMBER> | --all}"
+
+  if [[ "$target" == "--all" ]]; then
+    cleanup_all_via_ssh
+    return 0
+  fi
+
+  if ! [[ "$target" =~ ^[0-9]+$ ]] || [[ "$target" == "0" ]]; then
+    echo "PR number must be a positive integer, got: ${target}" >&2
+    exit 1
+  fi
+
+  cleanup_pr "$target"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Adds `preview-cleanup.yml` to remove Coolify preview containers when a PR closes
- Adds `scripts/coolify-preview-cleanup.sh` with SSH fallback for our Coolify version

## Setup
GitHub variable `COOLIFY_SSH_HOST` and secret `COOLIFY_SSH_PRIVATE_KEY` are already configured.